### PR TITLE
Feat#21 open ai 연동

### DIFF
--- a/backend_set/build.gradle
+++ b/backend_set/build.gradle
@@ -142,6 +142,14 @@ dependencies {
     // Java Mail API
     implementation 'com.sun.mail:javax.mail:1.6.2' // 최신 JDK는 jakarta.mail 사용
 
+    //open ai 용
+    implementation 'org.springframework:spring-web:5.3.32' // RestTemplate 포함
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2' // JSON 파싱용
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13' // HTTP 통신
+    // OkHttp 라이브러리 추가
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    // JSON 파싱을 위한 org.json
+    implementation 'org.json:json:20240303'
 
 }
 // 테스트 실행 설정

--- a/backend_set/src/main/java/org/funding/config/RootConfig.java
+++ b/backend_set/src/main/java/org/funding/config/RootConfig.java
@@ -19,7 +19,8 @@ import javax.sql.DataSource;
 @PropertySource({"classpath:/application.properties"})
 @MapperScan({
         "org.funding.user.dao",
-        "org.funding.emailAuth.dao"
+        "org.funding.emailAuth.dao",
+        "org.funding.openAi.dao",
 })
 public class RootConfig {
   @Value("${jdbc.driver}")

--- a/backend_set/src/main/java/org/funding/config/ServletConfig.java
+++ b/backend_set/src/main/java/org/funding/config/ServletConfig.java
@@ -39,7 +39,9 @@ import org.springframework.web.servlet.view.JstlView;
         "org.funding.user.service",
         "org.funding.config",
         "org.funding.emailAuth.controller",
-        "org.funding.emailAuth.service"
+        "org.funding.emailAuth.service",
+        "org.funding.openAi.controller.OpenAiController",
+        "org.funding.openAi.service.OpenAiService"
 }) // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/backend_set/src/main/java/org/funding/config/ServletConfig.java
+++ b/backend_set/src/main/java/org/funding/config/ServletConfig.java
@@ -40,8 +40,9 @@ import org.springframework.web.servlet.view.JstlView;
         "org.funding.config",
         "org.funding.emailAuth.controller",
         "org.funding.emailAuth.service",
-        "org.funding.openAi.controller.OpenAiController",
-        "org.funding.openAi.service.OpenAiService"
+        "org.funding.openAi.controller",
+        "org.funding.openAi.service",
+        "org.funding.openAi.client",
 }) // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/backend_set/src/main/java/org/funding/openAi/client/OpenAIClient.java
+++ b/backend_set/src/main/java/org/funding/openAi/client/OpenAIClient.java
@@ -1,0 +1,52 @@
+package org.funding.openAi.client;
+
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OpenAIClient {
+
+    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
+
+    @Value("${openai.api.key}")
+    private String API_KEY;
+
+
+    public String askOpenAI(String prompt) {
+        try {
+            OkHttpClient client = new OkHttpClient();
+
+            MediaType mediaType = MediaType.parse("application/json");
+            JSONObject requestBody = new JSONObject();
+            requestBody.put("model", "gpt-3.5-turbo");
+            JSONArray messages = new JSONArray();
+            JSONObject message = new JSONObject();
+            message.put("role", "user");
+            message.put("content", prompt);
+            messages.put(message);
+            requestBody.put("messages", messages);
+
+            Request request = new Request.Builder()
+                    .url(API_URL)
+                    .addHeader("Authorization",API_KEY)
+                    .addHeader("Content-Type", "application/json")
+                    .post(RequestBody.create(requestBody.toString(), mediaType))
+                    .build();
+
+            Response response = client.newCall(request).execute();
+            JSONObject json = new JSONObject(response.body().string());
+            return json.getJSONArray("choices")
+                    .getJSONObject(0)
+                    .getJSONObject("message")
+                    .getString("content");
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "Error occurred while calling OpenAI API";
+        }
+    }
+}

--- a/backend_set/src/main/java/org/funding/openAi/client/OpenAIClient.java
+++ b/backend_set/src/main/java/org/funding/openAi/client/OpenAIClient.java
@@ -1,5 +1,6 @@
 package org.funding.openAi.client;
 
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -8,45 +9,66 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 public class OpenAIClient {
 
-    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
+    private static final String API_URL = "https://api.openai.com/v1/completions";
+    private static final MediaType MEDIA_TYPE = MediaType.parse("application/json");
 
     @Value("${openai.api.key}")
-    private String API_KEY;
-
+    private String apiKey;
 
     public String askOpenAI(String prompt) {
-        try {
-            OkHttpClient client = new OkHttpClient();
+        OkHttpClient client = new OkHttpClient();
 
-            MediaType mediaType = MediaType.parse("application/json");
+        try {
+            // 1. 요청 바디 구성
             JSONObject requestBody = new JSONObject();
             requestBody.put("model", "gpt-3.5-turbo");
+
             JSONArray messages = new JSONArray();
-            JSONObject message = new JSONObject();
-            message.put("role", "user");
-            message.put("content", prompt);
-            messages.put(message);
+            JSONObject userMessage = new JSONObject();
+            userMessage.put("role", "user");
+            userMessage.put("content", prompt);
+            messages.put(userMessage);
             requestBody.put("messages", messages);
 
+            // 2. 요청 생성
             Request request = new Request.Builder()
                     .url(API_URL)
-                    .addHeader("Authorization",API_KEY)
+                    .addHeader("Authorization", "Bearer " + apiKey)
                     .addHeader("Content-Type", "application/json")
-                    .post(RequestBody.create(requestBody.toString(), mediaType))
+                    .post(RequestBody.create(requestBody.toString(), MEDIA_TYPE))
                     .build();
 
+            // 3. 요청 실행
             Response response = client.newCall(request).execute();
-            JSONObject json = new JSONObject(response.body().string());
+
+            if (!response.isSuccessful()) {
+                log.error("OpenAI API 호출 실패: HTTP {}", response.code());
+                return "OpenAI API 요청 실패 (" + response.code() + ")";
+            }
+
+            String responseBody = response.body().string();
+            log.info("OpenAI 응답: {}", responseBody);
+
+            // 4. 응답 파싱
+            JSONObject json = new JSONObject(responseBody);
+            if (!json.has("choices")) {
+                log.error("OpenAI 응답에 'choices' 키가 없음: {}", responseBody);
+                return "OpenAI 응답 오류: 예상한 응답 형식이 아님.";
+            }
+
             return json.getJSONArray("choices")
                     .getJSONObject(0)
                     .getJSONObject("message")
                     .getString("content");
+
         } catch (IOException e) {
-            e.printStackTrace();
-            return "Error occurred while calling OpenAI API";
+            log.error("OpenAI API 요청 중 예외 발생", e);
+            return "OpenAI API 요청 중 오류가 발생했습니다.";
         }
     }
 }
+

--- a/backend_set/src/main/java/org/funding/openAi/controller/OpenAiController.java
+++ b/backend_set/src/main/java/org/funding/openAi/controller/OpenAiController.java
@@ -22,5 +22,4 @@ public class OpenAiController {
     public ChatResponseDTO ask(@RequestBody ChatRequestDTO chatRequestDTO) {
         return chatService.ask(chatRequestDTO);
     }
-
 }

--- a/backend_set/src/main/java/org/funding/openAi/controller/OpenAiController.java
+++ b/backend_set/src/main/java/org/funding/openAi/controller/OpenAiController.java
@@ -1,0 +1,26 @@
+package org.funding.openAi.controller;
+
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.funding.openAi.dto.ChatRequestDTO;
+import org.funding.openAi.dto.ChatResponseDTO;
+import org.funding.openAi.service.ChatService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ai")
+@RequiredArgsConstructor
+public class OpenAiController {
+
+    private final ChatService chatService;
+
+    @PostMapping(value = "/ask", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ChatResponseDTO ask(@RequestBody ChatRequestDTO chatRequestDTO) {
+        return chatService.ask(chatRequestDTO);
+    }
+
+}

--- a/backend_set/src/main/java/org/funding/openAi/dao/ChatDAO.java
+++ b/backend_set/src/main/java/org/funding/openAi/dao/ChatDAO.java
@@ -1,0 +1,10 @@
+package org.funding.openAi.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.funding.openAi.vo.ChatLogVO;
+
+@Mapper
+public interface ChatDAO {
+    // ai 채팅 기록 저장
+    void insertChatLog(ChatLogVO chatLogVO);
+}

--- a/backend_set/src/main/java/org/funding/openAi/dto/ChatRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/openAi/dto/ChatRequestDTO.java
@@ -1,0 +1,12 @@
+package org.funding.openAi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRequestDTO {
+    private String prompt;
+}

--- a/backend_set/src/main/java/org/funding/openAi/dto/ChatResponseDTO.java
+++ b/backend_set/src/main/java/org/funding/openAi/dto/ChatResponseDTO.java
@@ -1,0 +1,12 @@
+package org.funding.openAi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatResponseDTO {
+    private String response;
+}

--- a/backend_set/src/main/java/org/funding/openAi/service/ChatService.java
+++ b/backend_set/src/main/java/org/funding/openAi/service/ChatService.java
@@ -1,0 +1,35 @@
+package org.funding.openAi.service;
+
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.funding.openAi.client.OpenAIClient;
+import org.funding.openAi.dao.ChatDAO;
+import org.funding.openAi.dto.ChatRequestDTO;
+import org.funding.openAi.dto.ChatResponseDTO;
+import org.funding.openAi.vo.ChatLogVO;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final OpenAIClient openAIClient;
+
+    private final ChatDAO chatDAO;
+
+    public ChatResponseDTO ask(ChatRequestDTO chatRequestDTO) {
+        String prompt = chatRequestDTO.getPrompt();
+        String answer = openAIClient.askOpenAI(prompt);
+
+        ChatLogVO chatLog = new ChatLogVO();
+        chatLog.setPrompt(prompt);
+        chatLog.setResponse(answer);
+        chatLog.setCreateAt(new Date());
+
+        chatDAO.insertChatLog(chatLog);
+
+        return new ChatResponseDTO(answer);
+    }
+}

--- a/backend_set/src/main/java/org/funding/openAi/service/ChatService.java
+++ b/backend_set/src/main/java/org/funding/openAi/service/ChatService.java
@@ -26,7 +26,7 @@ public class ChatService {
         ChatLogVO chatLog = new ChatLogVO();
         chatLog.setPrompt(prompt);
         chatLog.setResponse(answer);
-        chatLog.setCreateAt(new Date());
+        chatLog.setCreatedAt(new Date());
 
         chatDAO.insertChatLog(chatLog);
 

--- a/backend_set/src/main/java/org/funding/openAi/vo/ChatLogVO.java
+++ b/backend_set/src/main/java/org/funding/openAi/vo/ChatLogVO.java
@@ -1,0 +1,13 @@
+package org.funding.openAi.vo;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class ChatLogVO {
+    private Long id;
+    private String prompt;
+    private String response;
+    private Date createAt;
+}

--- a/backend_set/src/main/java/org/funding/openAi/vo/ChatLogVO.java
+++ b/backend_set/src/main/java/org/funding/openAi/vo/ChatLogVO.java
@@ -9,5 +9,5 @@ public class ChatLogVO {
     private Long id;
     private String prompt;
     private String response;
-    private Date createAt;
+    private Date createdAt;
 }

--- a/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
+++ b/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
@@ -128,7 +128,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                             "/swagger-resources/**",
                             "/webjars/**",
                             "/mail/send",
-                            "mail/verify").permitAll()
+                            "mail/verify",
+                            "/ai/ask").permitAll()
             .antMatchers("/api/security/all").permitAll()
             .antMatchers("/api/security/member").hasRole("MEMBER")
             .antMatchers("/api/security/admin").hasRole("ADMIN")
@@ -162,7 +163,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             "/v2/api-docs",
             "/v3/api-docs",
             "/mail/send",
-            "/mail/verify"
+            "/mail/verify",
+            "/ai/ask"
     );
   }
 }

--- a/backend_set/src/main/resources/application.properties
+++ b/backend_set/src/main/resources/application.properties
@@ -7,4 +7,4 @@ jdbc.driver=com.mysql.cj.jdbc.Driver
 jdbc.url=jdbc:mysql://localhost:3306/fund_DB?allowPublicKeyRetrieval=true&useSSL=false
 jdbc.username=${DB_USERNAME}
 jdbc.password=${DB_PASSWORD}
-
+openai.api.key=${OPEN_AI_KEY}

--- a/backend_set/src/main/resources/org/funding/openAi/dao/ChatDAO.xml
+++ b/backend_set/src/main/resources/org/funding/openAi/dao/ChatDAO.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.funding.openAi.dao.ChatDAO">
+
+    <!-- 채팅 로그 삽입 -->
+    <insert id="insertChatLog" parameterType="org.funding.openAi.vo.ChatLogVO">
+        INSERT INTO chat_log (prompt, response, created_at)
+        VALUES (#{prompt}, #{response}, #{createdAt})
+    </insert>
+
+<!--    &lt;!&ndash; 채팅 로그 전체 조회 &ndash;&gt;-->
+<!--    <select id="getAllChatLogs" resultType="org.funding.openAi.vo.ChatLogVO">-->
+<!--        SELECT id, prompt, response, created_at-->
+<!--        FROM chat_log-->
+<!--        ORDER BY created_at DESC-->
+<!--    </select>-->
+
+<!--    &lt;!&ndash; 채팅 로그 단건 조회 &ndash;&gt;-->
+<!--    <select id="getChatLogById" parameterType="long" resultType="org.funding.openAi.vo.ChatLogVO">-->
+<!--        SELECT id, prompt, response, created_at-->
+<!--        FROM chat_log-->
+<!--        WHERE id = #{id}-->
+<!--    </select>-->
+
+<!--    &lt;!&ndash; 채팅 로그 삭제 &ndash;&gt;-->
+<!--    <delete id="deleteChatLogById" parameterType="long">-->
+<!--        DELETE FROM chat_log-->
+<!--        WHERE id = #{id}-->
+<!--    </delete>-->
+
+</mapper>


### PR DESCRIPTION
### 🔧 PR 제목:

`feat: OpenAI GPT 연동 및 채팅 로그 DB 저장 기능 구현`

#### 📌 PR 타입

* [x] 기능 추가
* [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

#### 📌 이슈 번호

close #21 

---

### ✨ 반영 브랜치

`feat#21-open-ai` → `develop`

---

### ✅ 작업 개요

* OpenAI GPT-3.5-Turbo API 연동을 통해 사용자 프롬프트에 대한 응답 생성 기능 추가
* 사용자 입력(prompt)과 OpenAI의 응답(content)을 DB에 저장하는 기능 구현

---

### 🔨 주요 변경 사항

1. **`OpenAIClient` 컴포넌트 추가**

   * `@Component`로 등록
   * OkHttp + JSON 사용
   * Chat completion 요청을 보내고 응답 메시지를 추출
   * 응답 검증 및 에러 로깅 추가
   * `application.properties`에서 API 키 로딩 (`@Value`)

2. **`ChatService` 비즈니스 로직 구성**

   * 클라이언트로부터 전달된 프롬프트 → OpenAI 요청
   * 응답을 받아 DB에 로그 기록 (`ChatLogVO`)
   * 결과를 `ChatResponseDTO`에 담아 반환

3. **`ChatLogVO` 수정**

   * `createdAt` 필드 명시
   * 마이바티스 매퍼 연동 시 오류 방지를 위한 네이밍 일치 처리

---

### 🧪 테스트

* 실제 프롬프트를 입력해 응답이 잘 반환되는지 확인
* 응답 결과가 DB 테이블에 정상적으로 INSERT되는지 검증
* API 키 누락/오류 시 예외 처리 확인
* OpenAI API 응답 포맷이 예상과 다를 경우 로그로 확인

---

### 🙏 리뷰 요청 사항

* 서비스와 클라이언트 계층 분리에 대한 구조적 피드백
* OkHttp 사용 방식 or JSON 파싱 처리 방식에 대한 개선 제안

