### PR TITLE
feat: 펀딩 추천 ai 기능 구현

### DIFF
--- a/backend_set/src/main/java/org/funding/openAi/controller/OpenAiController.java
+++ b/backend_set/src/main/java/org/funding/openAi/controller/OpenAiController.java
@@ -2,23 +2,34 @@ package org.funding.openAi.controller;
 
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.funding.fund.vo.FundVO;
+import org.funding.openAi.client.OpenAIClient;
 import org.funding.openAi.dto.ChatRequestDTO;
 import org.funding.openAi.dto.ChatResponseDTO;
 import org.funding.openAi.dto.SummaryFundRequestDTO;
 import org.funding.openAi.dto.SummaryFundResponseDTO;
 import org.funding.openAi.service.ChatService;
+import org.funding.openAi.service.FundAIService;
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/ai")
 @RequiredArgsConstructor
+@Log4j2
 public class OpenAiController {
 
     private final ChatService chatService;
+    private final FundAIService fundAIService;
 
     @PostMapping(value = "/ask", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ChatResponseDTO ask(@RequestBody ChatRequestDTO chatRequestDTO) {
@@ -30,4 +41,11 @@ public class OpenAiController {
     public SummaryFundResponseDTO summaryFund(@RequestBody SummaryFundRequestDTO summaryFundRequestDTO) {
         return chatService.summaryFund(summaryFundRequestDTO);
     }
+
+    // 현재 펀딩과 비슷한 펀딩 추천받기
+    @GetMapping(value = "/{fundId}/ai-recommend")
+    public List<FundVO> recommendSimilarFundsByAI(@PathVariable Long fundId) {
+        return fundAIService.aiSimilar(fundId);
+    }
+
 }

--- a/backend_set/src/main/java/org/funding/openAi/dao/FundAIDAO.java
+++ b/backend_set/src/main/java/org/funding/openAi/dao/FundAIDAO.java
@@ -1,0 +1,19 @@
+package org.funding.openAi.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.funding.fund.vo.FundVO;
+import org.funding.fund.vo.enumType.FundType;
+
+import java.util.List;
+
+@Mapper
+public interface FundAIDAO {
+
+    FundVO findFundById(Long fundId);
+
+    FundType findFundTypeByProductId(Long productId);
+
+    List<FundVO> findFundsByFundTypeExcludeSelf(@Param("fundType") String fundType, @Param("fundId") Long fundId);
+
+}

--- a/backend_set/src/main/java/org/funding/openAi/service/FundAIService.java
+++ b/backend_set/src/main/java/org/funding/openAi/service/FundAIService.java
@@ -1,0 +1,99 @@
+package org.funding.openAi.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.funding.fund.vo.FundVO;
+import org.funding.fund.vo.enumType.FundType;
+import org.funding.openAi.client.OpenAIClient;
+import org.funding.openAi.dao.FundAIDAO;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class FundAIService {
+
+    private final FundAIDAO fundAIDAO;
+    private final OpenAIClient openAIClient;
+
+    // id로 펀딩 상품 추출
+    public FundVO findFundById(Long fundId) {
+        return fundAIDAO.findFundById(fundId);
+    }
+
+    public List<FundVO> getSimilarFunds(Long fundId) {
+        FundVO fund = fundAIDAO.findFundById(fundId);
+        if (fund == null) {
+            throw new RuntimeException("해당 펀딩이 존재하지 않습니다");
+        }
+
+        FundType fundType = fundAIDAO.findFundTypeByProductId(fund.getProductId());
+        if (fundType == null) {
+            throw new RuntimeException("펀딩 상품의 타입 정보가 없습니다.");
+        }
+
+        return fundAIDAO.findFundsByFundTypeExcludeSelf(fundType.toString(), fundId);
+    }
+
+
+    public List<FundVO> aiSimilar(Long fundId) {
+        FundVO targetFund = findFundById(fundId);
+
+        if (targetFund == null) {
+            throw new RuntimeException("해당 펀딩이 존재하지 않습니다.");
+        }
+
+        List<FundVO> candidates = getSimilarFunds(fundId);
+        if (candidates.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("다음은 기준 펀딩과 동일한 유형의 펀딩입니다. ")
+                .append("기준 펀딩과 가장 유사한 10개 펀딩의 ID만 JSON 배열로 반환해주세요. 예: [1, 2, 3]\n\n");
+
+        prompt.append("기준 펀딩 \n").append(describeFund(targetFund)).append("\n\n");
+
+        prompt.append("비교 대상: \n");
+        for (FundVO fund : candidates) {
+            prompt.append("ID :").append(fund.getFundId())
+                    .append(" - ").append(describeFund(fund)).append("\n");
+        }
+
+        String aiResponse = openAIClient.askOpenAI(prompt.toString());
+        List<Long> recommendIds = parseFundIdsFromAIResponse(aiResponse);
+
+        return candidates.stream()
+                .filter(fund -> recommendIds.contains(fund.getFundId()))
+                .sorted(Comparator.comparingInt(f -> recommendIds.indexOf(f.getFundId())))
+                .collect(Collectors.toList());
+    }
+
+    private String describeFund(FundVO fund) {
+        return "금융사: " + fund.getFinancialInstitution() +
+                ", 시작일: " + fund.getLaunchAt() +
+                ", 종료일: " + fund.getEndAt();
+    }
+
+    private List<Long> parseFundIdsFromAIResponse(String response) {
+        try {
+            JSONArray array = new JSONArray(response);
+            List<Long> ids = new ArrayList<>();
+            for (int i =0; i< array.length(); i++) {
+                ids.add(array.getLong(i));
+            }
+            return ids;
+        } catch (JSONException e) {
+            log.error("Ai 응답 파싱 실패: {}", response);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
+++ b/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
@@ -133,6 +133,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                             "/ai/fund",
                             "/badge/create",
                             "/badge/{id}",
+                            "/ai/{fundId}/ai-recommend",
                             "/badge/all/badge").permitAll()
             .antMatchers("/api/security/all").permitAll()
             .antMatchers("/api/security/member").hasRole("MEMBER")
@@ -174,7 +175,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             "/ai/fund",
             "/badge/create",
             "/badge/{id}",
-            "/badge/all/badge"
+            "/badge/all/badge",
+            "/ai/{fundId}/ai-recommend"
     );
   }
 }

--- a/backend_set/src/main/resources/org/funding/openAi/dao/FundAIDAO.xml
+++ b/backend_set/src/main/resources/org/funding/openAi/dao/FundAIDAO.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.funding.openAi.dao.FundAIDAO">
+
+    <!-- fundId로 FundVO 조회 -->
+    <select id="findFundById" parameterType="long" resultType="org.funding.fund.vo.FundVO">
+        SELECT * FROM tbl_fund WHERE fund_id = #{fundId}
+    </select>
+
+    <!-- productId로 FundType 조회 -->
+    <select id="findFundTypeByProductId" parameterType="long" resultType="org.funding.fund.vo.enumType.FundType">
+        SELECT fund_type FROM tbl_financial_product WHERE product_id = #{productId}
+    </select>
+
+    <!-- 동일 FundType의 펀딩 조회 (자기 자신 제외) -->
+    <select id="findFundsByFundTypeExcludeSelf" resultType="org.funding.fund.vo.FundVO">
+        SELECT f.*
+        FROM tbl_fund f
+                 JOIN tbl_financial_product p ON f.product_id = p.product_id
+        WHERE p.fund_type = #{fundType}
+          AND f.fund_id != #{fundId}
+        ORDER BY f.launch_at DESC
+    </select>
+
+</mapper>


### PR DESCRIPTION
펀딩 추천 ai 기능 구현

📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
 기능 추가


 코드에 영향을 주지 않는 변경사항 (ex. 오타 수정, 탭 사이즈 변경, 변수명 변경)

📌 이슈 번호

close #39 

✨ 반영 브랜치
feat#39-similar-fund-ai → develop

🙏 리뷰 요청 사항
전체적으로 서비스 흐름이 명확한지
prompt 구성 방식에 문제가 없는지
AI 응답 파싱 방식이 안정적인지

✅ 구현 내용
🎯 기능 목적
사용자가 선택한 펀딩과 유사한 펀딩을 OpenAI API를 활용하여 추천해주는 기능입니다.

🧩 주요 구현 사항
FundAIService 구현

findFundById(Long fundId)
→ 특정 펀딩 ID로 펀딩 정보 조회

getSimilarFunds(Long fundId)
→ 같은 유형(FundType)의 펀딩 목록 추출 (자기 자신 제외)

aiSimilar(Long fundId)
→ OpenAI에 기준 펀딩과 비교 펀딩 정보를 전달하고,
응답 받은 유사 펀딩 ID 기준으로 결과 리스트 필터링 및 정렬 후 반환

OpenAIClient 구현
GPT API(gpt-3.5-turbo)와 연동해 유사 펀딩 추천 요청
OkHttp 기반 요청 및 응답 파싱 처리
