### PR TITLE
Feat#46 재출시 투표 기능 구현

### DIFF
--- a/backend_set/src/main/java/org/funding/config/RootConfig.java
+++ b/backend_set/src/main/java/org/funding/config/RootConfig.java
@@ -24,7 +24,8 @@ import javax.sql.DataSource;
         "org.funding.badge.dao",
         "org.funding.financialProduct.dao",
         "org.funding.fund.dao",
-        "org.funding.votes.dao"
+        "org.funding.votes.dao",
+        "org.funding.retryVotes.dao"
 })
 public class RootConfig {
   @Value("${jdbc.driver}")

--- a/backend_set/src/main/java/org/funding/config/ServletConfig.java
+++ b/backend_set/src/main/java/org/funding/config/ServletConfig.java
@@ -53,6 +53,8 @@ import java.util.List;
         "org.funding.badge.service",
         "org.funding.fund.controller",
         "org.funding.fund.service",
+        "org.funding.retryVotes.service",
+        "org.funding.retryVotes.controller",
 }) // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/backend_set/src/main/java/org/funding/fund/controller/FundController.java
+++ b/backend_set/src/main/java/org/funding/fund/controller/FundController.java
@@ -154,5 +154,4 @@ public class FundController {
         FundDetailResponseDTO fundDetail = fundService.getFundDetail(fundId);
         return ResponseEntity.ok(fundDetail);
     }
-
 }

--- a/backend_set/src/main/java/org/funding/fund/dto/FundDetailResponseDTO.java
+++ b/backend_set/src/main/java/org/funding/fund/dto/FundDetailResponseDTO.java
@@ -27,6 +27,7 @@ public class FundDetailResponseDTO {
     private LocalDateTime launchAt;
     private LocalDateTime endAt;
     private String financialInstitution;
+    private int retryVotesCount;
     
     // Financial Product 테이블 정보
     private String name;

--- a/backend_set/src/main/java/org/funding/fund/dto/FundListResponseDTO.java
+++ b/backend_set/src/main/java/org/funding/fund/dto/FundListResponseDTO.java
@@ -22,6 +22,7 @@ public class FundListResponseDTO {
     private LocalDateTime launchAt;
     private LocalDateTime endAt;
     private String financialInstitution;
+    private int retryVotesCount;
     
     // FinancialProduct 정보
     private String name;

--- a/backend_set/src/main/java/org/funding/fund/vo/FundVO.java
+++ b/backend_set/src/main/java/org/funding/fund/vo/FundVO.java
@@ -20,4 +20,5 @@ public class FundVO {
     private LocalDateTime launchAt; // 출시 날짜
     private LocalDateTime endAt; // 종료 날짜
     private String financialInstitution; // 금융사
+    private Integer retryVotesCount; // 재출시 투표 갯수
 }

--- a/backend_set/src/main/java/org/funding/retryVotes/controller/RetryVotesController.java
+++ b/backend_set/src/main/java/org/funding/retryVotes/controller/RetryVotesController.java
@@ -1,0 +1,29 @@
+package org.funding.retryVotes.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.funding.retryVotes.dto.DoVoteRequestDTO;
+import org.funding.retryVotes.service.RetryVotesService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/retryVotes")
+public class RetryVotesController {
+
+    private final RetryVotesService retryVotesService;
+
+
+    // 투표
+    @PostMapping("/do")
+    public ResponseEntity<String> doVote(@RequestBody DoVoteRequestDTO voteRequestDTO) {
+        return ResponseEntity.ok(retryVotesService.doVote(voteRequestDTO));
+    }
+
+    // 투표 취소 api
+    @DeleteMapping("/cancel")
+    public ResponseEntity<String> deleteVote(@RequestBody DoVoteRequestDTO voteRequestDTO) {
+        return ResponseEntity.ok(retryVotesService.deleteVote(voteRequestDTO));
+    }
+
+}

--- a/backend_set/src/main/java/org/funding/retryVotes/controller/RetryVotesController.java
+++ b/backend_set/src/main/java/org/funding/retryVotes/controller/RetryVotesController.java
@@ -26,4 +26,5 @@ public class RetryVotesController {
         return ResponseEntity.ok(retryVotesService.deleteVote(voteRequestDTO));
     }
 
+
 }

--- a/backend_set/src/main/java/org/funding/retryVotes/dao/RetryVotesDAO.java
+++ b/backend_set/src/main/java/org/funding/retryVotes/dao/RetryVotesDAO.java
@@ -1,0 +1,22 @@
+package org.funding.retryVotes.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.funding.retryVotes.dto.DoVoteRequestDTO;
+import org.funding.retryVotes.vo.RetryVotesVO;
+
+@Mapper
+public interface RetryVotesDAO {
+
+    // 투표 추가
+    int addRetryVotes(RetryVotesVO retryVotesVO);
+
+    // 특정 펀딩에 대한 투표 수 조회
+    int countRetryVotesByFundingId(Long fundingId);
+
+    // 중복 투표 방지용
+    boolean existsVoteByUserIdAndFundingId(@Param("userId") Long userId, @Param("fundingId") Long fundingId);
+
+    // 투표 취소
+    void deleteRetryVotes(DoVoteRequestDTO voteRequestDTO);
+}

--- a/backend_set/src/main/java/org/funding/retryVotes/dto/DoVoteRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/retryVotes/dto/DoVoteRequestDTO.java
@@ -1,0 +1,13 @@
+package org.funding.retryVotes.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DoVoteRequestDTO {
+    private Long userId; // 재출시 희망자 id
+    private Long fundId; // 펀딩 id
+}

--- a/backend_set/src/main/java/org/funding/retryVotes/service/RetryVotesService.java
+++ b/backend_set/src/main/java/org/funding/retryVotes/service/RetryVotesService.java
@@ -1,6 +1,8 @@
 package org.funding.retryVotes.service;
 
 import lombok.RequiredArgsConstructor;
+import org.funding.fund.dao.FundDAO;
+import org.funding.fund.vo.FundVO;
 import org.funding.retryVotes.dao.RetryVotesDAO;
 import org.funding.retryVotes.dto.DoVoteRequestDTO;
 import org.funding.retryVotes.vo.RetryVotesVO;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class RetryVotesService {
 
     private final RetryVotesDAO retryVotesDAO;
+    private final FundDAO fundDAO;
 
     // 투표 등록
     public String doVote(DoVoteRequestDTO voteRequestDTO) {
@@ -25,12 +28,32 @@ public class RetryVotesService {
         retryVotesVO.setFundingId(voteRequestDTO.getFundId());
         retryVotesDAO.addRetryVotes(retryVotesVO);
 
+        // 펀딩에 투표 수 추가
+        FundVO fund = fundDAO.selectById(voteRequestDTO.getFundId());
+        int count = fund.getRetryVotesCount();
+        if (count > 0) {
+            fund.setRetryVotesCount(fund.getRetryVotesCount() + 1);
+        }
+
         return "투표가 정상적으로 등록되었습니다.";
     }
 
     // 투표 취소
     public String deleteVote(DoVoteRequestDTO voteRequestDTO) {
+        boolean alreadyVoted = retryVotesDAO.existsVoteByUserIdAndFundingId(voteRequestDTO.getUserId(), voteRequestDTO.getFundId());
+        // 투표 취소방지
+        if (!alreadyVoted) {
+            throw new IllegalStateException("투표를 안하셨기에 투표를 취소 할 수 없습니다.");
+        }
+
         retryVotesDAO.deleteRetryVotes(voteRequestDTO);
+
+        // 펀딩에 투표 수 취소 반영
+        FundVO fund = fundDAO.selectById(voteRequestDTO.getFundId());
+        int count = fund.getRetryVotesCount();
+        if (count > 0) {
+            fund.setRetryVotesCount(fund.getRetryVotesCount() - 1);
+        }
         return "투표가 정상적으로 취소되었습니다";
     }
 

--- a/backend_set/src/main/java/org/funding/retryVotes/service/RetryVotesService.java
+++ b/backend_set/src/main/java/org/funding/retryVotes/service/RetryVotesService.java
@@ -3,6 +3,7 @@ package org.funding.retryVotes.service;
 import lombok.RequiredArgsConstructor;
 import org.funding.fund.dao.FundDAO;
 import org.funding.fund.vo.FundVO;
+import org.funding.fund.vo.enumType.ProgressType;
 import org.funding.retryVotes.dao.RetryVotesDAO;
 import org.funding.retryVotes.dto.DoVoteRequestDTO;
 import org.funding.retryVotes.vo.RetryVotesVO;
@@ -23,13 +24,19 @@ public class RetryVotesService {
             throw new IllegalStateException("이미 투표하신 펀딩입니다.");
         }
 
+        FundVO fund = fundDAO.selectById(voteRequestDTO.getFundId());
+
+        // 펀딩이 종료됐는지 검사
+        if (fund.getProgress() != ProgressType.End) {
+            throw new IllegalStateException("아직 펀딩이 종료되지 않았습니다.");
+        }
+
         RetryVotesVO retryVotesVO = new RetryVotesVO();
         retryVotesVO.setUserId(voteRequestDTO.getUserId());
         retryVotesVO.setFundingId(voteRequestDTO.getFundId());
         retryVotesDAO.addRetryVotes(retryVotesVO);
 
         // 펀딩에 투표 수 추가
-        FundVO fund = fundDAO.selectById(voteRequestDTO.getFundId());
         int count = fund.getRetryVotesCount();
         if (count > 0) {
             fund.setRetryVotesCount(fund.getRetryVotesCount() + 1);
@@ -46,10 +53,15 @@ public class RetryVotesService {
             throw new IllegalStateException("투표를 안하셨기에 투표를 취소 할 수 없습니다.");
         }
 
+        FundVO fund = fundDAO.selectById(voteRequestDTO.getFundId());
+
+        // 펀딩이 종료됐는지 검사
+        if (fund.getProgress() != ProgressType.End) {
+            throw new IllegalStateException("아직 펀딩이 종료되지 않았습니다.");
+        }
         retryVotesDAO.deleteRetryVotes(voteRequestDTO);
 
         // 펀딩에 투표 수 취소 반영
-        FundVO fund = fundDAO.selectById(voteRequestDTO.getFundId());
         int count = fund.getRetryVotesCount();
         if (count > 0) {
             fund.setRetryVotesCount(fund.getRetryVotesCount() - 1);

--- a/backend_set/src/main/java/org/funding/retryVotes/service/RetryVotesService.java
+++ b/backend_set/src/main/java/org/funding/retryVotes/service/RetryVotesService.java
@@ -1,0 +1,37 @@
+package org.funding.retryVotes.service;
+
+import lombok.RequiredArgsConstructor;
+import org.funding.retryVotes.dao.RetryVotesDAO;
+import org.funding.retryVotes.dto.DoVoteRequestDTO;
+import org.funding.retryVotes.vo.RetryVotesVO;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RetryVotesService {
+
+    private final RetryVotesDAO retryVotesDAO;
+
+    // 투표 등록
+    public String doVote(DoVoteRequestDTO voteRequestDTO) {
+        boolean alreadyVoted = retryVotesDAO.existsVoteByUserIdAndFundingId(voteRequestDTO.getUserId(), voteRequestDTO.getFundId());
+        // 중복 검사
+        if (alreadyVoted) {
+            throw new IllegalStateException("이미 투표하신 펀딩입니다.");
+        }
+
+        RetryVotesVO retryVotesVO = new RetryVotesVO();
+        retryVotesVO.setUserId(voteRequestDTO.getUserId());
+        retryVotesVO.setFundingId(voteRequestDTO.getFundId());
+        retryVotesDAO.addRetryVotes(retryVotesVO);
+
+        return "투표가 정상적으로 등록되었습니다.";
+    }
+
+    // 투표 취소
+    public String deleteVote(DoVoteRequestDTO voteRequestDTO) {
+        retryVotesDAO.deleteRetryVotes(voteRequestDTO);
+        return "투표가 정상적으로 취소되었습니다";
+    }
+
+}

--- a/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
+++ b/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
@@ -134,7 +134,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                             "/badge/create",
                             "/badge/{id}",
                             "/ai/{fundId}/ai-recommend",
-                            "/badge/all/badge").permitAll()
+                            "/badge/all/badge",
+                            "/retryVotes/do",
+                            "/retryVotes/cancel").permitAll()
             .antMatchers("/api/security/all").permitAll()
             .antMatchers("/api/security/member").hasRole("MEMBER")
             .antMatchers("/api/security/admin").hasRole("ADMIN")

--- a/backend_set/src/main/resources/application.properties
+++ b/backend_set/src/main/resources/application.properties
@@ -4,7 +4,7 @@
 # log4jdbc ?? ??
 # ?? ????
 jdbc.driver=com.mysql.cj.jdbc.Driver
-jdbc.url=jdbc:mysql://localhost:3306/fund_DB?allowPublicKeyRetrieval=true&useSSL=false
+jdbc.url=jdbc:mysql://localhost:3306/${DB_URL}?allowPublicKeyRetrieval=true&useSSL=false
 jdbc.username=${DB_USERNAME}
 jdbc.password=${DB_PASSWORD}
 openai.api.key=${OPEN_AI_KEY}

--- a/backend_set/src/main/resources/org/funding/fund/dao/FundDAO.xml
+++ b/backend_set/src/main/resources/org/funding/fund/dao/FundDAO.xml
@@ -100,6 +100,7 @@
             f.launch_at as launchAt, 
             f.end_at as endAt, 
             f.financial_institution as financialInstitution,
+            f.retry_votes_count as retryVotesCount,
             fp.name as name,
             fp.icon_url as thumbnail,
             fp.fund_type as fundType
@@ -122,6 +123,7 @@
             f.launch_at as launchAt,
             f.end_at as endAt,
             f.financial_institution as financialInstitution,
+            f.retry_votes_count as retryVotesCount,
             fp.name as name,
             fp.detail as detail,
             fp.fund_type as fundType,

--- a/backend_set/src/main/resources/org/funding/openAi/dao/FundAIDAO.xml
+++ b/backend_set/src/main/resources/org/funding/openAi/dao/FundAIDAO.xml
@@ -6,19 +6,19 @@
 
     <!-- fundId로 FundVO 조회 -->
     <select id="findFundById" parameterType="long" resultType="org.funding.fund.vo.FundVO">
-        SELECT * FROM tbl_fund WHERE fund_id = #{fundId}
+        SELECT * FROM fund WHERE fund_id = #{fundId}
     </select>
 
     <!-- productId로 FundType 조회 -->
     <select id="findFundTypeByProductId" parameterType="long" resultType="org.funding.fund.vo.enumType.FundType">
-        SELECT fund_type FROM tbl_financial_product WHERE product_id = #{productId}
+        SELECT fund_type FROM financial_product WHERE product_id = #{productId}
     </select>
 
     <!-- 동일 FundType의 펀딩 조회 (자기 자신 제외) -->
     <select id="findFundsByFundTypeExcludeSelf" resultType="org.funding.fund.vo.FundVO">
         SELECT f.*
-        FROM tbl_fund f
-                 JOIN tbl_financial_product p ON f.product_id = p.product_id
+        FROM fund f
+                 JOIN financial_product p ON f.product_id = p.product_id
         WHERE p.fund_type = #{fundType}
           AND f.fund_id != #{fundId}
         ORDER BY f.launch_at DESC

--- a/backend_set/src/main/resources/org/funding/retryVotes/dao/RetryVotesDAO.xml
+++ b/backend_set/src/main/resources/org/funding/retryVotes/dao/RetryVotesDAO.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.funding.retryVotes.dao.RetryVotesDAO">
+
+    <!-- 투표 삽입 -->
+    <insert id="addRetryVotes" parameterType="org.funding.retryVotes.dto.DoVoteRequestDTO">
+        INSERT INTO retry_votes (user_id, funding_id)
+        VALUES (#{userId}, #{fundingId})
+    </insert>
+
+    <!-- 펀딩별 투표 수 -->
+    <select id="countRetryVotesByFundingId" resultType="int" parameterType="long">
+        SELECT COUNT(*) FROM retry_votes WHERE funding_id = #{fundingId}
+    </select>
+
+    <!-- 유저가 이미 투표했는지 확인 -->
+    <select id="existsVoteByUserIdAndFundingId" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM retry_votes WHERE user_id = #{userId} AND funding_id = #{fundingId}
+        )
+    </select>
+
+<!--    투표 취소-->
+    <delete id="deleteRetryVotes" parameterType="org.funding.retryVotes.dto.DoVoteRequestDTO">
+        DELETE FROM funding_vote
+        WHERE user_id = #{userId}
+          AND funding_id = #{fundingId}
+    </delete>
+
+</mapper>

--- a/backend_set/src/main/resources/org/funding/user/dao/MemberDAO.xml
+++ b/backend_set/src/main/resources/org/funding/user/dao/MemberDAO.xml
@@ -5,7 +5,7 @@
 <mapper namespace="org.funding.user.dao.MemberDAO">
 
     <insert id="insertMember" parameterType="org.funding.user.vo.MemberVO">
-        INSERT INTO tbl_member (
+        INSERT INTO member (
             username, password, email, nickname, phone_number, role, create_at, update_at
         ) VALUES (
                      #{username}, #{password}, #{email}, #{nickname}, #{phoneNumber}, #{role}, NOW(), NOW()


### PR DESCRIPTION
## 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [x] 기능 추가
* [x] 버그 수정
* [ ] 코드 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 코드에 영향을 주지 않는 변경사항 (ex. 오타 수정, 탭 사이즈 변경, 변수명 변경)

---

## 📌 이슈 번호

close #46 

---

## ✨ 반영 브랜치

feat#46-retry-vote -> develop

---

## ✨ 구현 내용 요약

* 재출시 투표 등록 및 취소 기능 구현 (`RetryVotesService`)

  * 투표 등록 시:

    * 동일 유저의 중복 투표 방지
    * 펀딩 종료 여부 확인
    * `retry_votes` 테이블에 데이터 삽입
    * `fund.retry_votes_count` 필드 증가 처리
  * 투표 취소 시:

    * 투표 여부 확인 후 없을 경우 예외 발생
    * 펀딩 종료 여부 확인
    * `retry_votes` 테이블에서 데이터 삭제
    * `fund.retry_votes_count` 필드 감소 처리

---

## 🙏 리뷰 요청 사항

* 예외 처리 방식이 괜찮은지 검토 부탁드립니다.
* `fund.retry_votes_count` 필드의 직접 갱신 방식이 괜찮을지 피드백 부탁드립니다.
* 전체 흐름에서 개선할 수 있는 로직이 있으면 제안해주세요.
