### PR TITLE
Feat#60 챌린지 가입, 취소, 인증 기능 구현

### DIFF
--- a/backend_set/src/main/java/org/funding/challengeLog/controller/ChallengeLogController.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/controller/ChallengeLogController.java
@@ -1,0 +1,9 @@
+package org.funding.challengeLog.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/challengeLog")
+public class ChallengeLogController {
+}

--- a/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
@@ -1,0 +1,15 @@
+package org.funding.challengeLog.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.funding.challengeLog.vo.ChallengeLogVO;
+
+import java.time.LocalDate;
+
+@Mapper
+public interface ChallengeLogDAO {
+
+    void insertChallengeLog(ChallengeLogVO log);
+
+    ChallengeLogVO selectLogByUserAndDate(@Param("userChallengeId") Long id, @Param("logDate") LocalDate date);
+}

--- a/backend_set/src/main/java/org/funding/challengeLog/service/ChallengeLogService.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/service/ChallengeLogService.java
@@ -1,0 +1,7 @@
+package org.funding.challengeLog.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChallengeLogService {
+}

--- a/backend_set/src/main/java/org/funding/challengeLog/vo/ChallengeLogVO.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/vo/ChallengeLogVO.java
@@ -1,0 +1,19 @@
+package org.funding.challengeLog.vo;
+
+import lombok.Data;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+public class ChallengeLogVO {
+    private Long logId;
+    private Long userChallengeId;
+    private Long userId;
+    private boolean verified;
+    private String imageUrl;
+    private String verifiedResult;
+    private LocalDate logDate;
+    private Timestamp createAt;
+}

--- a/backend_set/src/main/java/org/funding/openAi/client/OpenAIVisionClient.java
+++ b/backend_set/src/main/java/org/funding/openAi/client/OpenAIVisionClient.java
@@ -29,7 +29,9 @@ public class OpenAIVisionClient {
 
             JSONObject textObject = new JSONObject();
             textObject.put("type", "text");
-            textObject.put("text", prompt);
+            String refinedPrompt = prompt +
+                    " 이 조건을 만족하는지 판단해줘. 만약 사진이 이 조건에 부합한다면 '확인되었습니다.'라는 문장을 마지막에 꼭 포함해서 답변해줘.";
+            textObject.put("text", refinedPrompt);
             contentArray.put(textObject);
 
             JSONObject imageObject = new JSONObject();

--- a/backend_set/src/main/java/org/funding/user/dao/MemberDAO.java
+++ b/backend_set/src/main/java/org/funding/user/dao/MemberDAO.java
@@ -8,4 +8,6 @@ public interface MemberDAO {
     // 멤버 회원가입
     void insertMember(MemberVO member);
     MemberVO findByEmail(String username);
+
+    MemberVO findById(Long userId);
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
@@ -21,12 +21,11 @@ public class UserChallengeController {
         return ResponseEntity.ok("가입이 완료되었습니다");
     }
 
+
     // 첼린지 인증 로직
     @PostMapping("/{id}/verify")
     public ResponseEntity<?> verifyChallenge(@PathVariable("id") Long id, @RequestBody ChallengeRequestDTO challengeRequestDTO) {
-        userChallengeService.verifyDailyChallenge(id, challengeRequestDTO.getImageUrl(), challengeRequestDTO.getDate());
+        userChallengeService.verifyDailyChallenge(id, challengeRequestDTO.getUserId(), challengeRequestDTO.getImageUrl(), challengeRequestDTO.getDate());
         return ResponseEntity.ok("인증 완료");
     }
-
-
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
@@ -1,0 +1,32 @@
+package org.funding.userChallenge.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.funding.userChallenge.dto.ApplyChallengeRequestDTO;
+import org.funding.userChallenge.dto.ChallengeRequestDTO;
+import org.funding.userChallenge.service.UserChallengeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/userChallenge")
+@RequiredArgsConstructor
+public class UserChallengeController {
+
+    private final UserChallengeService userChallengeService;
+
+    // 첼린지 가입 신청 로직
+    @PostMapping("/{id}")
+    public ResponseEntity<?> applyChallenge(@PathVariable Long id, @RequestBody ApplyChallengeRequestDTO challengeRequestDTO) {
+        userChallengeService.applyChallenge(id, challengeRequestDTO);
+        return ResponseEntity.ok("가입이 완료되었습니다");
+    }
+
+    // 첼린지 인증 로직
+    @PostMapping("/{id}/verify")
+    public ResponseEntity<?> verifyChallenge(@PathVariable("id") Long id, @RequestBody ChallengeRequestDTO challengeRequestDTO) {
+        userChallengeService.verifyDailyChallenge(id, challengeRequestDTO.getImageUrl(), challengeRequestDTO.getDate());
+        return ResponseEntity.ok("인증 완료");
+    }
+
+
+}

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
@@ -3,6 +3,7 @@ package org.funding.userChallenge.controller;
 import lombok.RequiredArgsConstructor;
 import org.funding.userChallenge.dto.ApplyChallengeRequestDTO;
 import org.funding.userChallenge.dto.ChallengeRequestDTO;
+import org.funding.userChallenge.dto.DeleteChallengeRequestDTO;
 import org.funding.userChallenge.service.UserChallengeService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +22,12 @@ public class UserChallengeController {
         return ResponseEntity.ok("가입이 완료되었습니다");
     }
 
+    // 첼린지 가입 취소 로직
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteChallenge(@PathVariable Long id, @RequestBody DeleteChallengeRequestDTO deleteChallengeRequestDTO) {
+        userChallengeService.deleteChallenge(id, deleteChallengeRequestDTO);
+        return ResponseEntity.ok("정상적으로 챌린지에 취소되었습니다.");
+    }
 
     // 첼린지 인증 로직
     @PostMapping("/{id}/verify")

--- a/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
@@ -17,4 +17,7 @@ public interface UserChallengeDAO {
     void updateUserChallengeFail(@Param("userChallengeId") Long id);
 
     void updateChallengeStatus(@Param("userChallengeId") Long id, @Param("status") String status);
+
+    // 유저가 첼린지에 가입되어있는지 여부
+    boolean existsByIdAndUserId(@Param("fundId") Long fundId, @Param("userId") Long userId);
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
@@ -20,4 +20,9 @@ public interface UserChallengeDAO {
 
     // 유저가 첼린지에 가입되어있는지 여부
     boolean existsByIdAndUserId(@Param("fundId") Long fundId, @Param("userId") Long userId);
+
+    UserChallengeVO findById(@Param("userChallengeId") Long id);
+
+    // 유저 챌린지 참여 취소
+    void deleteUserChallenge(@Param("userChallengeId") Long id);
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
@@ -1,0 +1,20 @@
+package org.funding.userChallenge.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.funding.challengeLog.vo.ChallengeLogVO;
+import org.funding.userChallenge.vo.UserChallengeVO;
+
+import java.time.LocalDate;
+
+@Mapper
+public interface UserChallengeDAO {
+
+    void insertUserChallenge(UserChallengeVO challengeVO);
+
+    void updateUserChallengeSuccess(@Param("userChallengeId") Long id);
+
+    void updateUserChallengeFail(@Param("userChallengeId") Long id);
+
+    void updateChallengeStatus(@Param("userChallengeId") Long id, @Param("status") String status);
+}

--- a/backend_set/src/main/java/org/funding/userChallenge/dto/ApplyChallengeRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dto/ApplyChallengeRequestDTO.java
@@ -1,0 +1,8 @@
+package org.funding.userChallenge.dto;
+
+import lombok.Data;
+
+@Data
+public class ApplyChallengeRequestDTO {
+    private Long userId;
+}

--- a/backend_set/src/main/java/org/funding/userChallenge/dto/ChallengeRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dto/ChallengeRequestDTO.java
@@ -1,0 +1,11 @@
+package org.funding.userChallenge.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class ChallengeRequestDTO {
+    private String imageUrl;
+    private LocalDate date;
+}

--- a/backend_set/src/main/java/org/funding/userChallenge/dto/ChallengeRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dto/ChallengeRequestDTO.java
@@ -8,4 +8,5 @@ import java.time.LocalDate;
 public class ChallengeRequestDTO {
     private String imageUrl;
     private LocalDate date;
+    private Long userId;
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/dto/DeleteChallengeRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dto/DeleteChallengeRequestDTO.java
@@ -1,0 +1,8 @@
+package org.funding.userChallenge.dto;
+
+import lombok.Data;
+
+@Data
+public class DeleteChallengeRequestDTO {
+    private Long userId;
+}

--- a/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
@@ -79,7 +79,7 @@ public class UserChallengeService {
 
         ChallengeLogVO existing = challengeLogDAO.selectLogByUserAndDate(userChallengeId, logDate);
         if (existing != null) {
-            throw new RuntimeException("이미 인증 되었습니다");
+            throw new RuntimeException("금일은 이미 인증 되었습니다");
         }
 
         ChallengeLogVO log = new ChallengeLogVO();

--- a/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
@@ -1,0 +1,74 @@
+package org.funding.userChallenge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.funding.challengeLog.dao.ChallengeLogDAO;
+import org.funding.challengeLog.vo.ChallengeLogVO;
+import org.funding.financialProduct.dao.FinancialProductDAO;
+import org.funding.financialProduct.vo.FinancialProductVO;
+import org.funding.openAi.client.OpenAIVisionClient;
+import org.funding.user.dao.MemberDAO;
+import org.funding.user.vo.MemberVO;
+import org.funding.userChallenge.dao.UserChallengeDAO;
+import org.funding.userChallenge.dto.ApplyChallengeRequestDTO;
+import org.funding.userChallenge.vo.UserChallengeVO;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class UserChallengeService {
+
+    private final UserChallengeDAO userChallengeDAO;
+    private final OpenAIVisionClient openAIVisionClient;
+    private final ChallengeLogDAO challengeLogDAO;
+    private final FinancialProductDAO financialProductDAO;
+    private final MemberDAO memberDAO;
+
+    // 첼린지 가입 로직 (가입 전에 결제 로직 추가해줘야함)
+    public void applyChallenge(Long productId, ApplyChallengeRequestDTO challengeRequestDTO) {
+        FinancialProductVO financialProductVO = financialProductDAO.selectById(productId);
+        // 상품 예외처리
+        if (financialProductVO == null) {
+            throw new RuntimeException("존재하지 않는 상품 id 입니다.");
+        }
+
+        // 유저 예외처리
+        MemberVO memberVO = memberDAO.findById(challengeRequestDTO.getUserId());
+        if (memberVO == null) {
+            throw new RuntimeException("존재하지 않는 유저입니다.");
+        }
+
+        UserChallengeVO userChallengeVO = new UserChallengeVO();
+        userChallengeVO.setUserId(challengeRequestDTO.getUserId());
+        userChallengeVO.setProductId(productId);
+        userChallengeDAO.insertUserChallenge(userChallengeVO);
+    }
+
+
+    // 첼린지 인증 로직
+    public void verifyDailyChallenge(Long userChallengeId, String imageUrl, LocalDate logDate) {
+
+        String result = openAIVisionClient.analyzeImageWithPrompt(imageUrl, "해당 검증 입력값");
+        boolean isVerified = result.contains("검증 물체") && result.contains("검증 행위");
+
+        ChallengeLogVO existing = challengeLogDAO.selectLogByUserAndDate(userChallengeId, logDate);
+        if (existing != null) {
+            throw new RuntimeException("이미 인증 되었습니다");
+        }
+
+        ChallengeLogVO log = new ChallengeLogVO();
+        log.setUserChallengeId(userChallengeId);
+        log.setLogDate(logDate);
+        log.setImageUrl(imageUrl);
+        log.setVerified(isVerified);
+        log.setVerifiedResult(result);
+        challengeLogDAO.insertChallengeLog(log);
+
+        if (isVerified) {
+            userChallengeDAO.updateUserChallengeSuccess(userChallengeId);
+        } else {
+            userChallengeDAO.updateUserChallengeFail(userChallengeId);
+        }
+    }
+}

--- a/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
@@ -5,6 +5,9 @@ import org.funding.challengeLog.dao.ChallengeLogDAO;
 import org.funding.challengeLog.vo.ChallengeLogVO;
 import org.funding.financialProduct.dao.FinancialProductDAO;
 import org.funding.financialProduct.vo.FinancialProductVO;
+import org.funding.fund.dao.FundDAO;
+import org.funding.fund.vo.FundVO;
+import org.funding.fund.vo.enumType.ProgressType;
 import org.funding.openAi.client.OpenAIVisionClient;
 import org.funding.user.dao.MemberDAO;
 import org.funding.user.vo.MemberVO;
@@ -24,13 +27,21 @@ public class UserChallengeService {
     private final ChallengeLogDAO challengeLogDAO;
     private final FinancialProductDAO financialProductDAO;
     private final MemberDAO memberDAO;
+    private final FundDAO fundDAO;
 
     // 첼린지 가입 로직 (가입 전에 결제 로직 추가해줘야함)
-    public void applyChallenge(Long productId, ApplyChallengeRequestDTO challengeRequestDTO) {
-        FinancialProductVO financialProductVO = financialProductDAO.selectById(productId);
+    public void applyChallenge(Long fundId, ApplyChallengeRequestDTO challengeRequestDTO) {
+        FundVO fund = fundDAO.selectById(fundId);
+
         // 상품 예외처리
-        if (financialProductVO == null) {
-            throw new RuntimeException("존재하지 않는 상품 id 입니다.");
+        if (fund == null) {
+            throw new RuntimeException("존재하지 않는 펀딩 입니다.");
+        }
+
+        // 진행중인 펀딩 예외처리
+        ProgressType type = fund.getProgress();
+        if (type != ProgressType.Launch) {
+            throw new RuntimeException("해당 펀딩은 종료되었습니다.");
         }
 
         // 유저 예외처리
@@ -39,15 +50,29 @@ public class UserChallengeService {
             throw new RuntimeException("존재하지 않는 유저입니다.");
         }
 
+
+        // 중복가입 예외처리
+        boolean isVerify = userChallengeDAO.existsByIdAndUserId(fundId, challengeRequestDTO.getUserId());
+        if (isVerify) {
+            throw new RuntimeException("이미 첼린지에 가입된 회원입니다");
+        }
+
+
         UserChallengeVO userChallengeVO = new UserChallengeVO();
         userChallengeVO.setUserId(challengeRequestDTO.getUserId());
-        userChallengeVO.setProductId(productId);
+        userChallengeVO.setFundId(fundId);
         userChallengeDAO.insertUserChallenge(userChallengeVO);
     }
 
 
     // 첼린지 인증 로직
-    public void verifyDailyChallenge(Long userChallengeId, String imageUrl, LocalDate logDate) {
+    public void verifyDailyChallenge(Long userChallengeId, Long userId, String imageUrl, LocalDate logDate) {
+
+        // 해당 사용자가 첼린지에 가입이 되어있는지
+        boolean isVerify = userChallengeDAO.existsByIdAndUserId(userChallengeId, userId);
+        if (!isVerify) {
+            throw new RuntimeException("해당 유저는 첼린지에 가입되어있지 않습니다.");
+        }
 
         String result = openAIVisionClient.analyzeImageWithPrompt(imageUrl, "해당 검증 입력값");
         boolean isVerified = result.contains("검증 물체") && result.contains("검증 행위");

--- a/backend_set/src/main/java/org/funding/userChallenge/vo/UserChallengeVO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/vo/UserChallengeVO.java
@@ -6,7 +6,7 @@ import org.funding.userChallenge.vo.enumType.ChallengeStatus;
 @Data
 public class UserChallengeVO {
     private Long userChallengeId;
-    private Long productId;
+    private Long fundId;
     private Long userId;
     private int currentCount;
     private int failCount;

--- a/backend_set/src/main/java/org/funding/userChallenge/vo/UserChallengeVO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/vo/UserChallengeVO.java
@@ -1,0 +1,14 @@
+package org.funding.userChallenge.vo;
+
+import lombok.Data;
+import org.funding.userChallenge.vo.enumType.ChallengeStatus;
+
+@Data
+public class UserChallengeVO {
+    private Long userChallengeId;
+    private Long productId;
+    private Long userId;
+    private int currentCount;
+    private int failCount;
+    private ChallengeStatus challengeStatus; // 진행 상태
+}

--- a/backend_set/src/main/java/org/funding/userChallenge/vo/enumType/ChallengeStatus.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/vo/enumType/ChallengeStatus.java
@@ -1,0 +1,16 @@
+package org.funding.userChallenge.vo.enumType;
+
+public enum ChallengeStatus {
+
+    InProgress, Success, Fail;
+
+    public static ChallengeStatus fromString(String value) {
+        for (ChallengeStatus status : ChallengeStatus.values()) {
+            if (status.name().equals(value)) {
+                return status;
+            }
+        }
+
+        throw new IllegalArgumentException("알수없는 권한: " + value);
+    }
+}

--- a/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
+++ b/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.funding.challengeLog.dao.ChallengeLogDAO">
+
+    <!-- 인증 로그 저장 -->
+    <insert id="insertChallengeLog" parameterType="org.funding.challengeLog.vo.ChallengeLogVO">
+        INSERT INTO challenge_log (
+            user_challenge_id, log_date, verified, image_url, verified_result
+        )
+        VALUES (
+                   #{userChallengeId}, #{logDate}, #{verified}, #{imageUrl}, #{verifiedResult}
+               )
+    </insert>
+
+    <!-- 특정 날짜에 대한 인증 로그 조회 -->
+    <select id="selectLogByUserAndDate" resultType="org.funding.challengeLog.vo.ChallengeLogVO">
+        SELECT *
+        FROM challenge_log
+        WHERE user_challenge_id = #{userChallengeId}
+          AND log_date = #{logDate}
+    </select>
+
+
+</mapper>

--- a/backend_set/src/main/resources/org/funding/user/dao/MemberDAO.xml
+++ b/backend_set/src/main/resources/org/funding/user/dao/MemberDAO.xml
@@ -28,7 +28,24 @@
             WHERE email = #{email}
         </select>
 
-    </mapper>
+<!--    id로 유저 찾기-->
+    <select id="findById" parameterType="long" resultType="org.funding.user.vo.MemberVO">
+        SELECT
+            user_id,
+            username,
+            password,
+            email,
+            nickname,
+            phone_number,
+            role,
+            create_at,
+            update_at
+        FROM tbl_member
+        WHERE user_id = #{userId}
+    </select>
+
+
+</mapper>
 
 
 

--- a/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
@@ -44,6 +44,22 @@
           AND user_id = #{userId}
     </select>
 
+<!--    id로 첼린지 조회-->
+    <select id="findById" resultType="org.funding.userChallenge.vo.UserChallengeVO" parameterType="long">
+        SELECT
+            user_challenge_id,
+            fund_id,
+            user_id,
+            success_count,
+            fail_count,
+        FROM user_challenge
+        WHERE user_challenge_id = #{userChallengeId}
+    </select>
 
+    <!-- ID로 유저 챌린지 삭제 -->
+    <delete id="deleteUserChallenge" parameterType="long">
+        DELETE FROM user_challenge
+        WHERE user_challenge_id = #{userChallengeId}
+    </delete>
 
 </mapper>

--- a/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
@@ -36,4 +36,14 @@
         WHERE user_challenge_id = #{userChallengeId}
     </update>
 
+<!--    유저가 첼린지 동참여부 판단-->
+    <select id="existsByIdAndUserId" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM user_challenge
+        WHERE fund_id = #{fundId}
+          AND user_id = #{userId}
+    </select>
+
+
+
 </mapper>

--- a/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.funding.userChallenge.dao.UserChallengeDAO">
+
+    <!-- 사용자 챌린지 참여 등록 -->
+    <insert id="insertUserChallenge" parameterType="org.funding.userChallenge.vo.UserChallengeVO">
+        INSERT INTO user_challenge (
+            user_id, challenge_id, start_date, end_date
+        )
+        VALUES (
+                   #{userId}, #{challengeId}, #{startDate}, #{endDate}
+               )
+    </insert>
+
+    <!-- 인증 성공 시 성공 카운트 증가 -->
+    <update id="updateUserChallengeSuccess">
+        UPDATE user_challenge
+        SET success_count = success_count + 1
+        WHERE user_challenge_id = #{userChallengeId}
+    </update>
+
+    <!-- 인증 실패 시 실패 카운트 증가 -->
+    <update id="updateUserChallengeFail">
+        UPDATE user_challenge
+        SET fail_count = fail_count + 1
+        WHERE user_challenge_id = #{userChallengeId}
+    </update>
+
+    <!-- 챌린지 상태 변경 ('성공', '실패', '진행중') -->
+    <update id="updateChallengeStatus">
+        UPDATE user_challenge
+        SET status = #{status}
+        WHERE user_challenge_id = #{userChallengeId}
+    </update>
+
+</mapper>


### PR DESCRIPTION
## 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [x] 기능 추가
* [x] 코드 리팩토링
* [ ] 버그 수정
* [ ] 기능 삭제
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 코드에 영향을 주지 않는 변경사항 (ex. 오타 수정, 탭 사이즈 변경, 변수명 변경)

## 📌 이슈 번호

close #60 

---

## ✨ 반영 브랜치

`feat/#60-join-challenge` → `develop`

---

## 📄 주요 변경 사항 및 구현 내용 요약

### 1. **챌린지 가입 기능 (`applyChallenge`)**

* 유저가 펀딩 상품 중 챌린지 유형에 가입할 수 있도록 구현
* 중복 가입, 유효한 펀딩 여부, 유저 존재 여부 등 예외처리 추가

### 2. **AI 이미지 인증 기능 (`verifyDailyChallenge`)**

* OpenAI Vision API를 이용한 이미지 분석
* 챌린지 리워드 기준(`rewardCondition`)을 기준으로 이미지 검증 수행
* AI 응답에서 `"확인되었습니다."`가 포함될 경우에만 인증 성공 처리
* 하루 한 번 인증 제한 (중복 인증 방지)
* 인증 성공 시 성공 카운트 증가, 인증 로그 DB에 저장

### 3. **챌린지 탈퇴 기능 (`deleteChallenge`)**

* 사용자가 자신의 챌린지 참여를 취소할 수 있는 기능
* 유저 및 참여 내역 존재 여부에 따른 예외처리 추가

---

## 📦 주요 연동 사항

* `OpenAIVisionClient`: OpenAI Vision API를 통해 이미지 분석 수행
* `ChallengeLogDAO`, `UserChallengeDAO`: 인증 내역 및 챌린지 상태 처리용 DAO 사용
