### PR TITLE
Feat#68 [금융 상품] 대출 기부 가입, 관리 기능 구현

### DIFF
--- a/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
+++ b/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
@@ -24,13 +24,13 @@ public class UserDonationController {
 
 
     // 기부 내역 상세 조회
-    @GetMapping("/{id}")
+    @GetMapping("/donation/{id}")
     public ResponseEntity<UserDonationVO> getDonation(@PathVariable("id") Long id) {
         return ResponseEntity.ok(userDonationService.getDonation(id));
     }
 
     // 유저의 기부 내역 전체 조회
-    @GetMapping("/{id}")
+    @GetMapping("/donation-history/{id}")
     public ResponseEntity<List<UserDonationVO>> getAllDonations(@PathVariable("id") Long id) {
         return ResponseEntity.ok(userDonationService.getAllDonations(id));
     }

--- a/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
+++ b/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
@@ -1,0 +1,49 @@
+package org.funding.userDonation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.funding.userDonation.dto.DonateRequestDTO;
+import org.funding.userDonation.dto.DonateResponseDTO;
+import org.funding.userDonation.service.UserDonationService;
+import org.funding.userDonation.vo.UserDonationVO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/user-saving")
+@RequiredArgsConstructor
+public class UserDonationController {
+
+    private final UserDonationService userDonationService;
+    // 기부
+    @PostMapping("/saving")
+    public ResponseEntity<DonateResponseDTO> donate(@RequestBody DonateRequestDTO donateRequestDTO) {
+        return ResponseEntity.ok(userDonationService.donate(donateRequestDTO));
+    }
+
+
+    // 기부 내역 상세 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<UserDonationVO> getDonation(@PathVariable("id") Long id) {
+        return ResponseEntity.ok(userDonationService.getDonation(id));
+    }
+
+    // 유저의 기부 내역 전체 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<List<UserDonationVO>> getAllDonations(@PathVariable("id") Long id) {
+        return ResponseEntity.ok(userDonationService.getAllDonations(id));
+    }
+
+    // 기부 내역 수정 (관리자용)
+    @PatchMapping("/{id}")
+    public ResponseEntity<String> updateDonation(@PathVariable("id") Long id, @RequestBody DonateRequestDTO donateRequestDTO) {
+        return ResponseEntity.ok(userDonationService.updateDonation(id, donateRequestDTO));
+    }
+
+    // 기부 내역 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteDonation(@PathVariable("id") Long id) {
+        return ResponseEntity.ok(userDonationService.deleteDonation(id));
+    }
+}

--- a/backend_set/src/main/java/org/funding/userDonation/dao/UserDonationDAO.java
+++ b/backend_set/src/main/java/org/funding/userDonation/dao/UserDonationDAO.java
@@ -1,0 +1,25 @@
+package org.funding.userDonation.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.funding.userDonation.vo.UserDonationVO;
+
+import java.util.List;
+
+@Mapper
+public interface UserDonationDAO {
+    // 기부 내역 생성
+    void insertUserDonation(UserDonationVO userDonationVO);
+
+    // 단건 조회
+    UserDonationVO findById(@Param("userDonationId") Long userDonationId);
+
+    // 유저 id로 조회
+    List<UserDonationVO> findByUserId(@Param("userId") Long userId);
+
+    // 내역 업데이트
+    void updateUserDonation(UserDonationVO userDonationVO);
+
+    // 기부 내역 삭제
+    void deleteUserDonation(@Param("userDonationId") Long userDonationId);
+}

--- a/backend_set/src/main/java/org/funding/userDonation/dto/DonateRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/userDonation/dto/DonateRequestDTO.java
@@ -1,0 +1,11 @@
+package org.funding.userDonation.dto;
+
+import lombok.Data;
+
+@Data
+public class DonateRequestDTO {
+    private Long fundId;
+    private Long userId;
+    private Integer donateAmount;
+    private boolean anonymous; // 익명 여부
+}

--- a/backend_set/src/main/java/org/funding/userDonation/dto/DonateResponseDTO.java
+++ b/backend_set/src/main/java/org/funding/userDonation/dto/DonateResponseDTO.java
@@ -1,0 +1,9 @@
+package org.funding.userDonation.dto;
+
+import lombok.Data;
+
+@Data
+public class DonateResponseDTO {
+    private String userName;
+    private Integer donateAmount;
+}

--- a/backend_set/src/main/java/org/funding/userDonation/service/UserDonationService.java
+++ b/backend_set/src/main/java/org/funding/userDonation/service/UserDonationService.java
@@ -1,0 +1,124 @@
+package org.funding.userDonation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.funding.financialProduct.dao.DonationDAO;
+import org.funding.financialProduct.vo.DonationVO;
+import org.funding.fund.dao.FundDAO;
+import org.funding.fund.vo.FundVO;
+import org.funding.fund.vo.enumType.ProgressType;
+import org.funding.user.dao.MemberDAO;
+import org.funding.user.vo.MemberVO;
+import org.funding.userDonation.dao.UserDonationDAO;
+import org.funding.userDonation.dto.DonateRequestDTO;
+import org.funding.userDonation.dto.DonateResponseDTO;
+import org.funding.userDonation.vo.UserDonationVO;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserDonationService {
+    private final MemberDAO memberDAO;
+    private final UserDonationDAO userDonationDAO;
+    private final DonationDAO donationDAO;
+    private final FundDAO fundDAO;
+
+    // 기부
+    public DonateResponseDTO donate(DonateRequestDTO donateRequestDTO) {
+        Long userId = donateRequestDTO.getUserId();
+        Long fundId = donateRequestDTO.getFundId();
+
+        MemberVO member = validateMember(userId);
+        FundVO fund = validateFund(fundId);
+
+        Long productId = fund.getProductId();
+
+        // 기부 금액 검증
+        DonationVO donation = donationDAO.selectByProductId(productId);
+        Integer maxAmount = donation.getMaxDonationAmount();
+        Integer minAmount = donation.getMinDonationAmount();
+
+        if (donateRequestDTO.getDonateAmount() > maxAmount || donateRequestDTO.getDonateAmount() < minAmount) {
+            throw new RuntimeException("해당 금액은 기부 금액 범위에 벗어났습니다.");
+        }
+
+        UserDonationVO userDonationVO = new UserDonationVO();
+        userDonationVO.setUserId(userId);
+        userDonationVO.setDonationAmount(donateRequestDTO.getDonateAmount());
+        userDonationVO.setAnonymous(donateRequestDTO.isAnonymous());
+        userDonationDAO.insertUserDonation(userDonationVO);
+
+        DonateResponseDTO donateResponseDTO = new DonateResponseDTO();
+        donateResponseDTO.setUserName(member.getUsername());
+        donateResponseDTO.setDonateAmount(donateRequestDTO.getDonateAmount());
+        return donateResponseDTO;
+    }
+
+    // 기부 내역 단건 조회
+    public UserDonationVO getDonation(Long userDonationId) {
+        UserDonationVO userDonation = userDonationDAO.findById(userDonationId);
+        if (userDonation == null) {
+            throw new RuntimeException("해당 기부 내역이 존재하지 않습니다.");
+        }
+
+        return userDonation;
+    }
+
+    // 유저의 기부 내역 전체 조회
+    public List<UserDonationVO> getAllDonations(Long userId) {
+        MemberVO member = memberDAO.findById(userId);
+        if (member == null) {
+            throw new RuntimeException("해당 유저는 존재하지 않습니다.");
+        }
+
+        return userDonationDAO.findByUserId(userId);
+    }
+
+    // 기부 내역 수정
+    public String updateDonation(Long userDonationId, DonateRequestDTO donateRequestDTO) {
+        UserDonationVO userDonation = userDonationDAO.findById(userDonationId);
+        if (userDonation == null) {
+            throw new RuntimeException("해당 기부 내역이 존재하지 않습니다.");
+        }
+
+        userDonation.setDonationAmount(donateRequestDTO.getDonateAmount());
+        userDonation.setAnonymous(donateRequestDTO.isAnonymous());
+
+        userDonationDAO.updateUserDonation(userDonation);
+
+        return "기부 내역이 수정되었습니다.";
+    }
+
+    // 기부 내역 삭제
+    public String deleteDonation(Long userDonationId) {
+        UserDonationVO userDonationVO = userDonationDAO.findById(userDonationId);
+        if (userDonationVO == null) {
+            throw new RuntimeException("해당 기부 내역이 존재하지 않습니다.");
+        }
+
+        userDonationDAO.deleteUserDonation(userDonationId);
+        return "정상적으로 기부 내역이 삭제되었습니다.";
+    }
+    // 공통 검증 메서드
+    private MemberVO validateMember(Long userId) {
+        MemberVO member = memberDAO.findById(userId);
+        if (member == null) {
+            throw new RuntimeException("유효하지 않은 유저입니다.");
+        }
+        return member;
+    }
+
+    private FundVO validateFund(Long fundId) {
+        FundVO fund = fundDAO.selectById(fundId);
+        if (fund == null) {
+            throw new RuntimeException("펀딩이 존재하지 않습니다.");
+        }
+
+        if (fund.getProgress() == ProgressType.End) {
+            throw new RuntimeException("해당 기부는 종료되었습니다.");
+        }
+        return fund;
+    }
+
+}

--- a/backend_set/src/main/java/org/funding/userDonation/vo/UserDonationVO.java
+++ b/backend_set/src/main/java/org/funding/userDonation/vo/UserDonationVO.java
@@ -1,0 +1,11 @@
+package org.funding.userDonation.vo;
+
+import lombok.Data;
+
+@Data
+public class UserDonationVO {
+    private Long userDonationId;
+    private Long userId;
+    private Integer donationAmount; // 기부 금액
+    private boolean anonymous; // 익명 여부
+}

--- a/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
+++ b/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
@@ -1,0 +1,51 @@
+package org.funding.userLoan.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.funding.userLoan.dto.ApproveUserLoanRequestDTO;
+import org.funding.userLoan.dto.CancelLoanRequestDTO;
+import org.funding.userLoan.dto.UserLoanRequestDTO;
+import org.funding.userLoan.dto.UserLoanResponseDTO;
+import org.funding.userLoan.service.UserLoanService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user-loan")
+@RequiredArgsConstructor
+public class UserLoanController {
+
+    private final UserLoanService userLoanService;
+
+    // 대출 가입 (사용자용)
+    @PostMapping("/{id}")
+    public ResponseEntity<UserLoanResponseDTO> applyUserLoan(@PathVariable("id") Long id, @RequestBody UserLoanRequestDTO userLoanRequestDTO) {
+        return ResponseEntity.ok(userLoanService.applyLoan(id, userLoanRequestDTO).getBody());
+    }
+
+    // 대출 취소 (사용자용)
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> cancelUserLoan(@PathVariable("id") Long id, @RequestBody CancelLoanRequestDTO cancelLoanRequestDTO) {
+        userLoanService.cancelLoan(id, cancelLoanRequestDTO);
+        return ResponseEntity.ok("정상적으로 취소가 완료되었습니다.");
+    }
+
+    // 대출 승인 (관리자용)
+    @PatchMapping("/approve")
+    public ResponseEntity<String> approveUserLoan(@RequestBody ApproveUserLoanRequestDTO approveUserLoanRequestDTO) {
+        return ResponseEntity.ok(userLoanService.approveLoan(approveUserLoanRequestDTO));
+    }
+
+    // 대출 반려 (관리자용)
+    @PatchMapping("/reject")
+    public ResponseEntity<String> rejectUserLoan(@RequestBody ApproveUserLoanRequestDTO approveUserLoanRequestDTO) {
+        return ResponseEntity.ok(userLoanService.rejectLoan(approveUserLoanRequestDTO));
+    }
+
+    // 대출 지급 (관리자용)
+    @PatchMapping("/payment")
+    public ResponseEntity<String> UserLoan(@RequestBody ApproveUserLoanRequestDTO approveUserLoanRequestDTO) {
+        return ResponseEntity.ok(userLoanService.processLoanPayment(approveUserLoanRequestDTO));
+    }
+
+
+}

--- a/backend_set/src/main/java/org/funding/userLoan/dao/UserLoanDAO.java
+++ b/backend_set/src/main/java/org/funding/userLoan/dao/UserLoanDAO.java
@@ -1,0 +1,29 @@
+package org.funding.userLoan.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.funding.userLoan.dto.UserLoanRequestDTO;
+import org.funding.userLoan.vo.UserLoanVO;
+import org.funding.userLoan.vo.enumType.SuccessType;
+
+import java.util.List;
+
+@Mapper
+public interface UserLoanDAO {
+    // 대출 가입 신청
+    void insertUserLoan(UserLoanVO userLoanVO);
+
+    // id로 대출 내역 조회
+    UserLoanVO findById(Long userLoanId);
+
+    // 전체 조회
+    List<UserLoanVO> findAll();
+
+    // 대출 내역 수정 (사용 x)
+    void updateUserLoan(UserLoanVO userLoanVO);
+
+    // 대출 내역 삭제
+    void deleteUserLoan(Long userLoanId);
+
+    // 타입 기준 대출 조회(관리자용)
+    List<UserLoanVO> findByLoanAccess(SuccessType loanAccess);
+}

--- a/backend_set/src/main/java/org/funding/userLoan/dto/ApproveUserLoanRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/userLoan/dto/ApproveUserLoanRequestDTO.java
@@ -1,0 +1,11 @@
+package org.funding.userLoan.dto;
+
+import lombok.Data;
+import org.funding.userLoan.vo.enumType.SuccessType;
+
+@Data
+public class ApproveUserLoanRequestDTO {
+    private SuccessType type;
+    private Long userLoanId;
+    private Long userId;
+}

--- a/backend_set/src/main/java/org/funding/userLoan/dto/CancelLoanRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/userLoan/dto/CancelLoanRequestDTO.java
@@ -1,0 +1,8 @@
+package org.funding.userLoan.dto;
+
+import lombok.Data;
+
+@Data
+public class CancelLoanRequestDTO {
+    private Long userId;
+}

--- a/backend_set/src/main/java/org/funding/userLoan/dto/UserLoanRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/userLoan/dto/UserLoanRequestDTO.java
@@ -1,0 +1,9 @@
+package org.funding.userLoan.dto;
+
+import lombok.Data;
+
+@Data
+public class UserLoanRequestDTO {
+    private Long userId;
+    private Integer loanAmount; // 대출금
+}

--- a/backend_set/src/main/java/org/funding/userLoan/dto/UserLoanResponseDTO.java
+++ b/backend_set/src/main/java/org/funding/userLoan/dto/UserLoanResponseDTO.java
@@ -1,0 +1,9 @@
+package org.funding.userLoan.dto;
+
+import lombok.Data;
+
+@Data
+public class UserLoanResponseDTO {
+    private String userName;
+    private Integer loanAmount;
+}

--- a/backend_set/src/main/java/org/funding/userLoan/service/UserLoanService.java
+++ b/backend_set/src/main/java/org/funding/userLoan/service/UserLoanService.java
@@ -1,0 +1,141 @@
+package org.funding.userLoan.service;
+
+import lombok.RequiredArgsConstructor;
+import org.funding.fund.dao.FundDAO;
+import org.funding.fund.vo.FundVO;
+import org.funding.user.dao.MemberDAO;
+import org.funding.user.vo.MemberVO;
+import org.funding.userLoan.dao.UserLoanDAO;
+import org.funding.userLoan.dto.ApproveUserLoanRequestDTO;
+import org.funding.userLoan.dto.CancelLoanRequestDTO;
+import org.funding.userLoan.dto.UserLoanRequestDTO;
+import org.funding.userLoan.dto.UserLoanResponseDTO;
+import org.funding.userLoan.vo.UserLoanVO;
+import org.funding.userLoan.vo.enumType.SuccessType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserLoanService {
+    private final MemberDAO memberDAO;
+    private final FundDAO fundDAO;
+    private final UserLoanDAO userLoanDAO;
+
+    // 대출 승인 신청
+    public ResponseEntity<UserLoanResponseDTO> applyLoan(Long fundId, UserLoanRequestDTO loanRequestDTO) {
+        // 멤버 예외처리
+        MemberVO member = memberDAO.findById(loanRequestDTO.getUserId());
+        if (member == null) {
+            throw new RuntimeException("해당 멤버는 존재하지 않습니다.");
+        }
+
+        FundVO fund = fundDAO.selectById(fundId);
+        if (fund == null) {
+            throw new RuntimeException("해당 펀딩은 존재하지 않습니다.");
+        }
+
+        UserLoanVO userLoan = new UserLoanVO();
+        userLoan.setUserId(loanRequestDTO.getUserId());
+        userLoan.setFundId(fundId);
+        userLoan.setLoanAmount(loanRequestDTO.getLoanAmount());
+        userLoan.setLoanAccess(SuccessType.PENDING);
+        userLoan.setFullPayment(false);
+        userLoanDAO.insertUserLoan(userLoan);
+
+        UserLoanResponseDTO userLoanResponseDTO = new UserLoanResponseDTO();
+        userLoanResponseDTO.setUserName(member.getUsername());
+        userLoanResponseDTO.setLoanAmount(loanRequestDTO.getLoanAmount());
+
+        return ResponseEntity.ok(userLoanResponseDTO);
+    }
+
+    // 대출 승인 취소
+    public void cancelLoan(Long userLoanId, CancelLoanRequestDTO cancelLoanRequestDTO) {
+        // 회원 예외처리
+        MemberVO member = memberDAO.findById(cancelLoanRequestDTO.getUserId());
+        if (member == null) {
+            throw new RuntimeException("해당 멤버는 존재하지 않습니다.");
+        }
+
+        // 신청 여부 예외처리
+        UserLoanVO userLoan = userLoanDAO.findById(userLoanId);
+        if (userLoan == null) {
+            throw new RuntimeException("취소하실 신청내역이 존재하지 않습니다.");
+        }
+
+        // 지급 완료 여부 예외처리
+        if (userLoan.getLoanAccess() == SuccessType.DONE) {
+            throw new RuntimeException("이미 지급완료된 대출이라 취소하실 수 없습니다");
+        }
+
+        userLoanDAO.deleteUserLoan(userLoanId);
+    }
+
+    // 대출 승인 (관리자용)
+    public String approveLoan(ApproveUserLoanRequestDTO approveUserLoanRequestDTO) {
+        Long userId = approveUserLoanRequestDTO.getUserId();
+        Long userLoanId = approveUserLoanRequestDTO.getUserLoanId();
+
+        validateMember(userId);
+        UserLoanVO userLoan = validateLoan(userLoanId);
+
+        if (userLoan.getLoanAccess() != SuccessType.PENDING) {
+            throw new RuntimeException("이미 처리된 신청입니다.");
+        }
+
+        userLoan.setLoanAccess(SuccessType.APPROVED);
+        userLoanDAO.updateUserLoan(userLoan);
+
+        return "허가 완료";
+    }
+
+    public String rejectLoan(ApproveUserLoanRequestDTO approveUserLoanRequestDTO) {
+        Long userId = approveUserLoanRequestDTO.getUserId();
+        Long userLoanId = approveUserLoanRequestDTO.getUserLoanId();
+
+        validateMember(userId);
+        UserLoanVO userLoan = validateLoan(userLoanId);
+
+        if (userLoan.getLoanAccess() != SuccessType.PENDING) {
+            throw new RuntimeException("이미 처리된 신청입니다.");
+        }
+
+        userLoan.setLoanAccess(SuccessType.REJECTED);
+        userLoanDAO.updateUserLoan(userLoan);
+        return "반려 완료";
+    }
+
+    // 대출 지급
+    public String processLoanPayment(ApproveUserLoanRequestDTO approveUserLoanRequestDTO) {
+        Long userId = approveUserLoanRequestDTO.getUserId();
+        Long userLoanId = approveUserLoanRequestDTO.getUserLoanId();
+
+        validateMember(userId);
+        UserLoanVO userLoan = validateLoan(userLoanId);
+
+        if (userLoan.getLoanAccess() != SuccessType.APPROVED) {
+            throw new RuntimeException("지급은 승인된 후에만 가능합니다.");
+        }
+
+        userLoan.setLoanAccess(SuccessType.DONE);
+        userLoanDAO.updateUserLoan(userLoan);
+        return "지급 완료";
+    }
+
+    // 공통 검증 메서드
+    private void validateMember(Long userId) {
+        if (memberDAO.findById(userId) == null) {
+            throw new RuntimeException("유효하지 않은 유저입니다.");
+        }
+    }
+
+    private UserLoanVO validateLoan(Long userLoanId) {
+        UserLoanVO loan = userLoanDAO.findById(userLoanId);
+        if (loan == null) {
+            throw new RuntimeException("신청 내역이 존재하지 않습니다.");
+        }
+        return loan;
+    }
+
+}

--- a/backend_set/src/main/java/org/funding/userLoan/vo/UserLoanVO.java
+++ b/backend_set/src/main/java/org/funding/userLoan/vo/UserLoanVO.java
@@ -1,0 +1,14 @@
+package org.funding.userLoan.vo;
+
+import lombok.Data;
+import org.funding.userLoan.vo.enumType.SuccessType;
+
+@Data
+public class UserLoanVO {
+    private Long userLoanId;
+    private Long fundId;
+    private Long userId;
+    private Integer loanAmount; // 대출 금액
+    private SuccessType loanAccess; // 대출 승인 여부
+    private boolean fullPayment; // 완납 여부
+}

--- a/backend_set/src/main/java/org/funding/userLoan/vo/enumType/SuccessType.java
+++ b/backend_set/src/main/java/org/funding/userLoan/vo/enumType/SuccessType.java
@@ -1,0 +1,18 @@
+package org.funding.userLoan.vo.enumType;
+
+import org.funding.userChallenge.vo.enumType.ChallengeStatus;
+
+public enum SuccessType {
+    APPROVED, REJECTED, PENDING, DONE;
+    // 허가, 비허가, 대기중, 지급완료
+
+    public static SuccessType fromString(String value) {
+        for (SuccessType status : SuccessType.values()) {
+            if (status.name().equals(value)) {
+                return status;
+            }
+        }
+
+        throw new IllegalArgumentException("알수 없는 상태: " + value);
+    }
+}

--- a/backend_set/src/main/resources/org/funding/userDonation/dao/UserDonationDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userDonation/dao/UserDonationDAO.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.funding.userDonation.dao.UserDonationDAO">
+
+    <!-- 생성 -->
+    <insert id="insertUserDonation" parameterType="org.funding.userDonation.vo.UserDonationVO">
+        INSERT INTO user_saving (
+            user_id,
+            saving_amount,
+            anonymous
+        ) VALUES (
+                     #{userId},
+                     #{savingAmount},
+                     #{anonymous}
+                 )
+    </insert>
+
+    <!-- id로 단건 조회 -->
+    <select id="findById" parameterType="long" resultType="org.funding.userDonation.vo.UserDonationVO">
+        SELECT
+            user_saving_id,
+            user_id,
+            saving_amount,
+            anonymous
+        FROM user_saving
+        WHERE user_saving_id = #{userSavingId}
+    </select>
+
+    <!-- 유저 id로 전체 조회 -->
+    <select id="findByUserId" parameterType="long" resultType="org.funding.userDonation.vo.UserDonationVO">
+        SELECT
+            user_saving_id,
+            user_id,
+            saving_amount,
+            anonymous
+        FROM user_saving
+        WHERE user_id = #{userId}
+    </select>
+
+    <!-- 기부 내역 업데이트 -->
+    <update id="updateUserDonation" parameterType="org.funding.userDonation.vo.UserDonationVO">
+        UPDATE user_saving
+        SET
+            user_id = #{userId},
+            saving_amount = #{savingAmount},
+            anonymous = #{anonymous}
+        WHERE user_saving_id = #{userSavingId}
+    </update>
+
+    <!-- 삭제 -->
+    <delete id="deleteUserDonation" parameterType="long">
+        DELETE FROM user_saving
+        WHERE user_saving_id = #{userSavingId}
+    </delete>
+
+</mapper>

--- a/backend_set/src/main/resources/org/funding/userLoan/dao/UserLoanDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userLoan/dao/UserLoanDAO.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.funding.userLoan.dao.UserLoanDAO">
+
+    <!-- 저장 -->
+    <insert id="insertUserLoan" parameterType="org.funding.userLoan.vo.UserLoanVO" useGeneratedKeys="true" keyProperty="userLoanId">
+        INSERT INTO user_loan (fund_id, user_id, loan_amount, loan_access, full_payment)
+        VALUES (#{fundId}, #{userId}, #{loanAmount}, #{loanAccess}, #{fullPayment})
+    </insert>
+
+    <!-- 단건 조회 -->
+    <select id="findById" parameterType="long" resultType="org.funding.userLoan.vo.UserLoanVO">
+        SELECT user_loan_id, fund_id, user_id, loan_amount, loan_access, full_payment
+        FROM user_loan
+        WHERE user_loan_id = #{userLoanId}
+    </select>
+
+    <!-- 전체 조회 -->
+    <select id="findAll" resultType="org.funding.userLoan.vo.UserLoanVO">
+        SELECT user_loan_id, fund_id, user_id, loan_amount, loan_access, full_payment
+        FROM user_loan
+    </select>
+
+    <!-- 업데이트 -->
+    <update id="updateUserLoan" parameterType="org.funding.userLoan.vo.UserLoanVO">
+        UPDATE user_loan
+        SET fund_id = #{fundId},
+            user_id = #{userId},
+            loan_amount = #{loanAmount},
+            loan_access = #{loanAccess},
+            full_payment = #{fullPayment}
+        WHERE user_loan_id = #{userLoanId}
+    </update>
+
+    <!-- 삭제 -->
+    <delete id="deleteUserLoan" parameterType="long">
+        DELETE FROM user_loan WHERE user_loan_id = #{userLoanId}
+    </delete>
+
+    <!-- SuccessType 기준 조회 -->
+    <select id="findByLoanAccess" parameterType="org.funding.global.type.SuccessType" resultType="org.funding.userLoan.vo.UserLoanVO">
+        SELECT user_loan_id, fund_id, user_id, loan_amount, loan_access, full_payment
+        FROM user_loan
+        WHERE loan_access = #{loanAccess}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📌 이슈 번호
close #68 

## ✨ 반영 브랜치
feat/#23-loan-savings -> develop

## 📄 주요 변경 사항

### [기부(UserDonation) 기능 구현]
- 유저 기부 기능 구현 (`donate`)
  - 유저 ID, 펀딩 ID, 기부 금액, 익명 여부를 받아 기부 처리
  - 기부 금액이 `minAmount`, `maxAmount` 범위 내에 있는지 검증
- 기부 내역 단건 조회 기능 (`getDonation`)
- 기부 내역 전체 조회 기능 (`getAllDonations`)
- 기부 내역 수정 기능 (`updateDonation`)
  - 금액 및 익명 여부 수정
- 기부 내역 삭제 기능 (`deleteDonation`)
- Member, Fund, Donation 검증 로직 공통 메서드 분리 및 적용

### [대출(UserLoan) 기능 구현]
- 대출 신청 기능 (`applyLoan`)
  - 유저 ID와 펀딩 ID를 받아 대출 신청
  - 펀딩 상태가 종료되지 않았는지 검증
  - 대출 금액이 대출 한도 내에 있는지 확인
- 대출 신청 취소 기능 (`cancelLoan`)
  - PENDING 상태의 신청만 취소 가능, DONE 상태는 취소 불가
- 관리자 승인 기능 (`approveLoan`)
  - 신청 상태(PENDING)만 승인 가능, 처리된 신청은 예외 발생
- 관리자 반려 기능 (`rejectLoan`)
- 관리자 지급 처리 기능 (`processLoanPayment`)
  - APPROVED 상태만 지급 가능
- Member 및 Loan 공통 검증 메서드 분리

## 구현 방식 요약

- 서비스 계층에서 모든 도메인 검증(`member`, `fund`, `loan`)을 우선 처리하고,
- `VO` 객체에 DTO 값을 매핑하여 DAO로 전달
- MyBatis 기반으로 각 DAO 메서드 구현 예정 (`insert`, `update`, `delete`, `findById` 등)

## 리뷰 요청 사항

- `UserDonationService`와 `UserLoanService` 클래스의 책임 분리가 잘 이루어졌는지 확인 부탁드립니다.
- 기부/대출 각각의 예외 처리 흐름이 적절한지 검토 부탁드립니다.
  - 특히 펀딩 상태 확인, 금액 범위 검증, 승인/지급 상태 조건문 등
- `DTO -> VO -> DAO` 흐름이 명확하게 구조화되었는지 피드백 부탁드립니다.
- 서비스 내 중복되는 검증 로직을 적절히 분리하였는지 (validateMember, validateFund 등) 검토해주시면 감사하겠습니다.
- 혹시 추가적으로 단위 테스트가 필요한 포인트가 있다면 의견 부탁드립니다.


