### PR TITLE
Feat#135 s3 이미지 삭제

### DIFF
--- a/backend_set/src/main/java/org/funding/S3/dao/S3ImageDAO.java
+++ b/backend_set/src/main/java/org/funding/S3/dao/S3ImageDAO.java
@@ -20,4 +20,8 @@ public interface S3ImageDAO {
     // 이미지 한 개 출력
     S3ImageVO findFirstImageByPost(@Param("imageType") ImageType imageType, @Param("postId") Long postId);
 
+    // 이미지 삭제
+    void deleteImagesByPost(@Param("imageType") ImageType imageType, @Param("postId") Long postId);
+
+
 }

--- a/backend_set/src/main/java/org/funding/fund/service/FundService.java
+++ b/backend_set/src/main/java/org/funding/fund/service/FundService.java
@@ -557,7 +557,7 @@ public class FundService {
             // 2. fund 테이블에서 삭제 (외래키 제약 때문에 가장 먼저)
             fundDAO.delete(fundId);
             log.info("Fund deleted with id: {}", fundId);
-            
+
             // 3. 타입별 상세 테이블에서 삭제
             switch (fundType) {
                 case Savings:
@@ -581,7 +581,10 @@ public class FundService {
             // 4. financial_product 테이블에서 삭제 (외래키 참조가 없어진 후)
             financialProductDAO.delete(productId);
             log.info("Financial product deleted with id: {}", productId);
-            
+
+            // 해당 펀딩 이미지 삭제
+            s3ImageService.deleteImagesForPost(ImageType.Funding, productId);
+
             return "펀딩이 성공적으로 삭제되었습니다.";
             
         } catch (ResponseStatusException e) {

--- a/backend_set/src/main/java/org/funding/project/service/ProjectService.java
+++ b/backend_set/src/main/java/org/funding/project/service/ProjectService.java
@@ -267,6 +267,9 @@ public class ProjectService {
         }
 
         projectDAO.deleteProjectById(projectId);
+
+        // 프로젝트 관련 이미지 삭제
+        s3ImageService.deleteImagesForPost(ImageType.Project, projectId);
     }
 
     public List<KeywordVO> getProjectKeywords(Long projectId) {

--- a/backend_set/src/main/resources/org/funding/S3/dao/S3ImageDAO.xml
+++ b/backend_set/src/main/resources/org/funding/S3/dao/S3ImageDAO.xml
@@ -38,5 +38,13 @@
     </select>
 
 
+<!--    이미지 삭제-->
+    <delete id="deleteImagesByPost">
+        DELETE FROM image
+        WHERE image_type = #{imageType}
+          AND post_id = #{postId}
+    </delete>
+
+
 
 </mapper>


### PR DESCRIPTION
## 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 삭제

## 📌 이슈 번호
close #135 

## ✨ 반영 브랜치
feat#135-s3-image-delete -> develop

## 📄 작업 내용 요약
S3에 업로드된 게시물 이미지들을 삭제하는 기능을 구현하였습니다.  
게시물 삭제 또는 이미지 변경 시 불필요한 이미지가 S3에 남지 않도록 관리하기 위한 목적입니다.

- 게시글 타입(`ImageType`)과 게시글 ID(`postId`)로 해당 게시글에 업로드된 이미지들을 조회
- S3 URL로부터 Key를 추출하여 `amazonS3.deleteObject()`로 삭제
- DB에 저장된 이미지 정보 또한 일괄 삭제 (`s3ImageDAO.deleteImagesByPost(...)`)

## ✅ 주요 변경 사항
- `S3ImageService`에 `deleteImagesForPost(...)` 메서드 추가
- S3 이미지 URL에서 Key 추출하는 `extractKeyFromUrl()` 메서드 구현
- DAO (`S3ImageDAO`) 및 매퍼 XML에 이미지 삭제 쿼리 추가

## 🧪 테스트 내용
- 실제 게시글 이미지 업로드 후 `deleteImagesForPost()` 호출하여 S3 콘솔에서 객체 삭제 확인
- 삭제 후 DB에서도 이미지 메타데이터가 정상적으로 제거되는지 검증

## 🙏 리뷰 요청 사항
- 현재 `S3 URL → Key 추출` 로직이 단순히 `.com/` 이후를 자르는 방식인데, 더 안전한 방식이 있다면 피드백 부탁드립니다.
- `deleteImagesForPost()` 메서드의 책임 분리 또는 예외 처리 방식에 대해 의견 주시면 감사하겠습니다.
