### PR TITLE
Feat#137 auto badge grant

### DIFF
--- a/backend_set/src/main/java/org/funding/S3/vo/S3ImageVO.java
+++ b/backend_set/src/main/java/org/funding/S3/vo/S3ImageVO.java
@@ -4,14 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.funding.S3.vo.enumType.ImageType;
-
 import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class S3ImageVO {
-    private ImageType ImageType;
+    private ImageType imageType;
     private Long postId;
     private String imageUrl;
     private LocalDateTime createdAt;

--- a/backend_set/src/main/java/org/funding/badge/dao/BadgeDAO.java
+++ b/backend_set/src/main/java/org/funding/badge/dao/BadgeDAO.java
@@ -33,4 +33,15 @@ public interface BadgeDAO {
     List<BadgeVO> selectAutoGrantBadges();
     boolean hasUserBadge(@Param("userId") Long userId, @Param("badgeId") Long badgeId);
     void insertUserBadge(UserBadgeVO userBadgeVO);
+
+
+    // 뱃지 자동 부여 기능 (구체화)
+    boolean hasCompletedFundedProject(Long userId);
+    boolean isAdmin(Long userId);
+    boolean hasDonated(Long userId);
+    boolean hasJoinedChallenge(Long userId);
+    boolean hasSubscribedFinancialProduct(Long userId);
+    boolean hasProjectWithTenOrMoreComments(Long userId);
+    boolean hasPostedTenComments(Long userId);
+    boolean hasProjectWithTenOrMoreLikes(Long userId);
 }

--- a/backend_set/src/main/java/org/funding/badge/service/BadgeService.java
+++ b/backend_set/src/main/java/org/funding/badge/service/BadgeService.java
@@ -18,7 +18,6 @@ import java.util.List;
 public class BadgeService {
 
     private final BadgeDAO badgeDAO;
-    private final VotesDAO votesDAO;
 
     // 뱃지 생성
     public void createBadge(CreateBadgeDTO createBadgeDTO) {
@@ -64,11 +63,15 @@ public class BadgeService {
             }
 
             boolean isEligible = switch (badge.getAutoGrantCondition()) {
-                // 예시: 투표를 3회 이상할시 뱃지 부여 (아직 기획 구체화 더 필요)
-                case "VOTE_3_AND_POST_2" -> {
-                    int voteCount = votesDAO.countVotesByUserId(userId);
-                    yield voteCount >= 3;
-                }
+
+                case "COMPLETED_FUNDED_PROJECT" -> badgeDAO.hasCompletedFundedProject(userId);
+                case "ROLE_ADMIN" -> badgeDAO.isAdmin(userId);
+                case "DONATED" -> badgeDAO.hasDonated(userId);
+                case "CHALLENGE_PARTICIPANT" -> badgeDAO.hasJoinedChallenge(userId);
+                case "FINANCIAL_SUBSCRIBER" -> badgeDAO.hasSubscribedFinancialProduct(userId);
+                case "INFLUENCER" -> badgeDAO.hasProjectWithTenOrMoreComments(userId);
+                case "COMMENT_MASTER" -> badgeDAO.hasPostedTenComments(userId);
+                case "HIT_PROJECT_MAKER" -> badgeDAO.hasProjectWithTenOrMoreLikes(userId);
                 default -> false;
             };
 

--- a/backend_set/src/main/java/org/funding/fund/service/FundService.java
+++ b/backend_set/src/main/java/org/funding/fund/service/FundService.java
@@ -19,6 +19,9 @@ import org.funding.fund.dto.FundUpdateRequestDTO;
 import org.funding.fundKeyword.service.FundKeywordService;
 import org.funding.fundKeyword.dto.FundKeywordRequestDTO;
 import org.funding.keyword.vo.KeywordVO;
+import org.funding.project.dao.ProjectDAO;
+import org.funding.project.vo.ProjectVO;
+import org.funding.project.vo.enumType.ProjectProgress;
 import org.springframework.stereotype.Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.multipart.MultipartFile;
@@ -47,6 +50,7 @@ public class FundService {
     private final DonationDAO donationDAO;
     private final S3ImageService s3ImageService;
     private final FundKeywordService fundKeywordService;
+    private final ProjectDAO projectDAO;
 
     /**
      * 적금 펀딩 생성
@@ -98,6 +102,12 @@ public class FundService {
                 s3ImageService.uploadImagesForPost(ImageType.Funding, product.getProductId(), images);
             }
 
+            // 펀딩시 프로젝트 상태 변경
+            ProjectVO project = projectDAO.selectProjectById(request.getProjectId());
+            if (project != null) {
+                throw new RuntimeException("해당 프로젝트는 존재하지 않습니다.");
+            }
+            project.setProgress(ProjectProgress.FUNDED);
             
             // 5. 키워드 매핑 처리
             if (request.getKeywordIds() != null && !request.getKeywordIds().isEmpty()) {
@@ -171,6 +181,13 @@ public class FundService {
             if (images != null && images.size() > 0) {
                 s3ImageService.uploadImagesForPost(ImageType.Funding, product.getProductId(), images);
             }
+
+            // 펀딩시 프로젝트 상태 변경
+            ProjectVO project = projectDAO.selectProjectById(request.getProjectId());
+            if (project != null) {
+                throw new RuntimeException("해당 프로젝트는 존재하지 않습니다.");
+            }
+            project.setProgress(ProjectProgress.FUNDED);
             
             // 5. 키워드 매핑 처리
             if (request.getKeywordIds() != null && !request.getKeywordIds().isEmpty()) {
@@ -241,6 +258,13 @@ public class FundService {
             if (images != null && images.size() > 0) {
                 s3ImageService.uploadImagesForPost(ImageType.Funding, product.getProductId(), images);
             }
+
+            // 펀딩시 프로젝트 상태 변경
+            ProjectVO project = projectDAO.selectProjectById(request.getProjectId());
+            if (project != null) {
+                throw new RuntimeException("해당 프로젝트는 존재하지 않습니다.");
+            }
+            project.setProgress(ProjectProgress.FUNDED);
             
             // 5. 키워드 매핑 처리
             if (request.getKeywordIds() != null && !request.getKeywordIds().isEmpty()) {
@@ -312,6 +336,13 @@ public class FundService {
             if (images != null && images.size() > 0) {
                 s3ImageService.uploadImagesForPost(ImageType.Funding, product.getProductId(), images);
             }
+
+            // 펀딩시 프로젝트 상태 변경
+            ProjectVO project = projectDAO.selectProjectById(request.getProjectId());
+            if (project != null) {
+                throw new RuntimeException("해당 프로젝트는 존재하지 않습니다.");
+            }
+            project.setProgress(ProjectProgress.FUNDED);
             
             // 5. 키워드 매핑 처리
             if (request.getKeywordIds() != null && !request.getKeywordIds().isEmpty()) {

--- a/backend_set/src/main/java/org/funding/fund/service/FundService.java
+++ b/backend_set/src/main/java/org/funding/fund/service/FundService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.funding.S3.service.S3ImageService;
 import org.funding.S3.vo.S3ImageVO;
 import org.funding.S3.vo.enumType.ImageType;
+import org.funding.badge.service.BadgeService;
 import org.funding.financialProduct.dao.*;
 import org.funding.financialProduct.dto.*;
 import org.funding.financialProduct.vo.*;
@@ -51,6 +52,7 @@ public class FundService {
     private final S3ImageService s3ImageService;
     private final FundKeywordService fundKeywordService;
     private final ProjectDAO projectDAO;
+    private final BadgeService badgeService;
 
     /**
      * 적금 펀딩 생성
@@ -108,7 +110,9 @@ public class FundService {
                 throw new RuntimeException("해당 프로젝트는 존재하지 않습니다.");
             }
             project.setProgress(ProjectProgress.FUNDED);
-            
+
+            // 뱃지 권한 검증 (추후에 토큰 으로 유저 추출로 바꿔야댐)
+            badgeService.checkAndGrantBadges(project.getUserId());
             // 5. 키워드 매핑 처리
             if (request.getKeywordIds() != null && !request.getKeywordIds().isEmpty()) {
                 for (Long keywordId : request.getKeywordIds()) {

--- a/backend_set/src/main/java/org/funding/mapping/UserBadgeVO.java
+++ b/backend_set/src/main/java/org/funding/mapping/UserBadgeVO.java
@@ -11,3 +11,4 @@ public class UserBadgeVO {
     private Long badgeId; // 뱃지 id
     private LocalDateTime grantedAt; // 획득 날짜
 }
+

--- a/backend_set/src/main/java/org/funding/project/vo/enumType/ProjectProgress.java
+++ b/backend_set/src/main/java/org/funding/project/vo/enumType/ProjectProgress.java
@@ -1,7 +1,7 @@
 package org.funding.project.vo.enumType;
 
 public enum ProjectProgress {
-    Active, Closed;
+    Active, Closed, FUNDED;
 
     public static ProjectProgress fromString(String value) {
         for (ProjectProgress p : values()) {

--- a/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
+++ b/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
@@ -163,7 +163,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                             "/userSaving/apply",
                             "/userSaving/cancel/{id}",
                             "/userSaving/{id}",
-                            "/userSaving/user/{id}"
+                            "/userSaving/user/{id}",
+                            "/badge/create",
+                            "/badge/all/badge",
+                            "/badge/{id}"
                     ).permitAll()
             .antMatchers("/api/security/all").permitAll()
             .antMatchers("/api/security/member").hasRole("MEMBER")
@@ -239,7 +242,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             "/userSaving/apply",
             "/userSaving/cancel/{id}",
             "/userSaving/{id}",
-            "/userSaving/user/{id}"
+            "/userSaving/user/{id}",
+            "/badge/create",
+            "/badge/all/badge",
+            "/badge/{id}"
     );
   }
 }

--- a/backend_set/src/main/java/org/funding/user/service/MemberService.java
+++ b/backend_set/src/main/java/org/funding/user/service/MemberService.java
@@ -1,6 +1,7 @@
 package org.funding.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.funding.badge.service.BadgeService;
 import org.funding.security.util.JwtProcessor;
 import org.funding.user.dao.MemberDAO;
 import org.funding.user.dto.MemberSignupDTO;
@@ -18,6 +19,7 @@ public class MemberService {
     private final MemberDAO memberDAO;
     private final PasswordEncoder passwordEncoder;
     private final JwtProcessor jwtProcessor;
+    private final BadgeService badgeService;
 
     public void signup(MemberSignupDTO signupDTO) {
         MemberVO memberVO = new MemberVO();
@@ -40,6 +42,9 @@ public class MemberService {
         if (member == null || !passwordEncoder.matches(password, member.getPassword())) {
             throw new RuntimeException("비밀번호가 일치하지 않습니다, 회원이 없습니다"); // 임시 에러처리
         }
+
+        // 뱃지 자동 부여 검증
+        badgeService.checkAndGrantBadges(member.getUserId());
 
         return jwtProcessor.generateTokenWithRole(member.getUsername(), String.valueOf(member.getRole()));
     }

--- a/backend_set/src/main/resources/org/funding/badge/dao/BadgeDAO.xml
+++ b/backend_set/src/main/resources/org/funding/badge/dao/BadgeDAO.xml
@@ -119,11 +119,11 @@
             SELECT 1
             FROM project p
                      JOIN comment c
-                          ON c.targetType = 'Project'
-                              AND c.targetId = p.projectId
-            WHERE p.userId = #{userId}
-            GROUP BY p.projectId
-            HAVING COUNT(c.commentId) >= 10
+                          ON c.target_type = 'Project'
+                              AND c.target_id = p.project_id
+            WHERE p.user_id = #{userId}
+            GROUP BY p.project_id
+            HAVING COUNT(c.comment_id) >= 10
         )
     </select>
 
@@ -132,7 +132,7 @@
     <select id="hasPostedTenComments" resultType="boolean" parameterType="long">
         SELECT EXISTS(
             SELECT 1
-            FROM project_comment
+            FROM comment
             WHERE user_id = #{userId}
             GROUP BY user_id
             HAVING COUNT(comment_id) >= 10
@@ -143,11 +143,11 @@
     <select id="hasProjectWithTenOrMoreLikes" resultType="boolean" parameterType="long">
         SELECT EXISTS(
             SELECT 1
-            FROM donation_project dp
-                     JOIN project_like pl ON dp.project_id = pl.project_id
-            WHERE dp.user_id = #{userId}
-            GROUP BY dp.project_id
-            HAVING COUNT(pl.like_id) >= 10
+            FROM project p
+                     JOIN votes v ON v.project_id = p.project_id
+            WHERE p.user_Id = #{userId}
+            GROUP BY p.project_id
+            HAVING COUNT(v.vote_id) >= 10
         )
     </select>
 

--- a/backend_set/src/main/resources/org/funding/badge/dao/BadgeDAO.xml
+++ b/backend_set/src/main/resources/org/funding/badge/dao/BadgeDAO.xml
@@ -73,9 +73,9 @@
     <select id="isAdmin" resultType="boolean" parameterType="long">
         SELECT EXISTS(
             SELECT 1
-            FROM user
+            FROM member
             WHERE user_id = #{userId}
-              AND role = 'ADMIN'
+              AND role = 'ROLE_ADMIN'
         )
     </select>
 
@@ -83,8 +83,8 @@
     <select id="hasDonated" resultType="boolean" parameterType="long">
         SELECT EXISTS(
             SELECT 1
-            FROM donation
-            WHERE user_id = #{userId}
+            FROM user_donation
+            WHERE user_donation_id = #{userId}
         )
     </select>
 
@@ -92,8 +92,8 @@
     <select id="hasJoinedChallenge" resultType="boolean" parameterType="long">
         SELECT EXISTS(
             SELECT 1
-            FROM challenge_participant
-            WHERE user_id = #{userId}
+            FROM user_challenge
+            WHERE user_challenge_id = #{userId}
         )
     </select>
 
@@ -101,22 +101,32 @@
     <select id="hasSubscribedFinancialProduct" resultType="boolean" parameterType="long">
         SELECT EXISTS(
             SELECT 1
-            FROM user_financial_product
-            WHERE user_id = #{userId}
+            FROM user_saving
+            WHERE user_saving_id = #{userId}
+
+            UNION ALL
+
+            SELECT 1
+            FROM user_loan
+            WHERE user_loan_id = #{userId}
         )
     </select>
+
 
     <!-- 6. 인플루언서: 유저가 작성한 프로젝트에 댓글이 10개 이상 있는지 확인 -->
     <select id="hasProjectWithTenOrMoreComments" resultType="boolean" parameterType="long">
         SELECT EXISTS(
             SELECT 1
-            FROM donation_project dp
-                     JOIN project_comment pc ON dp.project_id = pc.project_id
-            WHERE dp.user_id = #{userId}
-            GROUP BY dp.project_id
-            HAVING COUNT(pc.comment_id) >= 10
+            FROM project p
+                     JOIN comment c
+                          ON c.targetType = 'Project'
+                              AND c.targetId = p.projectId
+            WHERE p.userId = #{userId}
+            GROUP BY p.projectId
+            HAVING COUNT(c.commentId) >= 10
         )
     </select>
+
 
     <!-- 7. 댓글왕: 유저가 단 댓글이 10개 이상인지 확인 -->
     <select id="hasPostedTenComments" resultType="boolean" parameterType="long">

--- a/backend_set/src/main/resources/org/funding/badge/dao/BadgeDAO.xml
+++ b/backend_set/src/main/resources/org/funding/badge/dao/BadgeDAO.xml
@@ -6,7 +6,7 @@
 
     <!--뱃지 생성 -->
     <insert id="insertBadge" parameterType="org.funding.badge.vo.BadgeVO">
-        INSERT INTO badge (name, description, autoGrantCondition)
+        INSERT INTO badge (name, description, auto_grant_condition)
         VALUES (#{name}, #{description}, #{autoGrantCondition})
     </insert>
 
@@ -15,7 +15,7 @@
         UPDATE badge
         SET name = #{name},
             description = #{description},
-            autoGrantCondition = #{autoGrantCondition}
+            auto_grant_condition = #{autoGrantCondition}
         WHERE badgeId = #{badgeId}
     </update>
 
@@ -27,14 +27,14 @@
 
     <!--단일 뱃지 조회 -->
     <select id="selectBadgeById" resultType="org.funding.badge.dto.BadgeResponseDTO" parameterType="long">
-        SELECT badgeId, name, description, autoGrantCondition
+        SELECT badgeId, name, description, auto_grant_condition
         FROM badge
         WHERE badgeId = #{badgeId}
     </select>
 
     <!--모든 뱃지 조회 -->
     <select id="selectAllBadges" resultType="org.funding.badge.dto.BadgeResponseDTO">
-        SELECT badgeId, name, description, autoGrantCondition
+        SELECT badgeId, name, description, auto_grant_condition
         FROM badge
     </select>
 
@@ -42,7 +42,7 @@
 
     <!-- 자동 부여 가능한 모든 뱃지를 조회 -->
     <select id="selectAutoGrantBadges" resultType="org.funding.badge.vo.BadgeVO">
-        SELECT * FROM badge WHERE autoGrantCondition IS NOT NULL
+        SELECT * FROM badge WHERE auto_grant_condition IS NOT NULL
     </select>
 
     <!-- 유저가 이미 보유한 뱃지인지 확인 -->
@@ -58,6 +58,89 @@
         INSERT INTO user_badge (user_id, badge_id, granted_at)
         VALUES (#{userId}, #{badgeId}, NOW())
     </insert>
+
+    <!-- 1. 업체 인증: 유저가 참여한 프로젝트 중 펀딩 완료된 프로젝트가 있는지 확인 -->
+    <select id="hasCompletedFundedProject" resultType="boolean" parameterType="long">
+        SELECT EXISTS(
+            SELECT 1
+            FROM project
+            WHERE user_id = #{userId}
+              AND progress = 'FUNDED' -- 펀딩 완료 상태
+        )
+    </select>
+
+    <!-- 2. 전문가: 유저의 역할이 관리자(ADMIN)인지 확인 -->
+    <select id="isAdmin" resultType="boolean" parameterType="long">
+        SELECT EXISTS(
+            SELECT 1
+            FROM user
+            WHERE user_id = #{userId}
+              AND role = 'ADMIN'
+        )
+    </select>
+
+    <!-- 3. 기부너: 유저가 기부 참여한 기록이 있는지 확인 -->
+    <select id="hasDonated" resultType="boolean" parameterType="long">
+        SELECT EXISTS(
+            SELECT 1
+            FROM donation
+            WHERE user_id = #{userId}
+        )
+    </select>
+
+    <!-- 4. 챌린저: 유저가 챌린지 참여한 기록이 있는지 확인 -->
+    <select id="hasJoinedChallenge" resultType="boolean" parameterType="long">
+        SELECT EXISTS(
+            SELECT 1
+            FROM challenge_participant
+            WHERE user_id = #{userId}
+        )
+    </select>
+
+    <!-- 5. 금융러: 유저가 금융상품 가입했는지 확인 -->
+    <select id="hasSubscribedFinancialProduct" resultType="boolean" parameterType="long">
+        SELECT EXISTS(
+            SELECT 1
+            FROM user_financial_product
+            WHERE user_id = #{userId}
+        )
+    </select>
+
+    <!-- 6. 인플루언서: 유저가 작성한 프로젝트에 댓글이 10개 이상 있는지 확인 -->
+    <select id="hasProjectWithTenOrMoreComments" resultType="boolean" parameterType="long">
+        SELECT EXISTS(
+            SELECT 1
+            FROM donation_project dp
+                     JOIN project_comment pc ON dp.project_id = pc.project_id
+            WHERE dp.user_id = #{userId}
+            GROUP BY dp.project_id
+            HAVING COUNT(pc.comment_id) >= 10
+        )
+    </select>
+
+    <!-- 7. 댓글왕: 유저가 단 댓글이 10개 이상인지 확인 -->
+    <select id="hasPostedTenComments" resultType="boolean" parameterType="long">
+        SELECT EXISTS(
+            SELECT 1
+            FROM project_comment
+            WHERE user_id = #{userId}
+            GROUP BY user_id
+            HAVING COUNT(comment_id) >= 10
+        )
+    </select>
+
+    <!-- 8. 히트메이커: 유저가 작성한 프로젝트에 좋아요 10개 이상 -->
+    <select id="hasProjectWithTenOrMoreLikes" resultType="boolean" parameterType="long">
+        SELECT EXISTS(
+            SELECT 1
+            FROM donation_project dp
+                     JOIN project_like pl ON dp.project_id = pl.project_id
+            WHERE dp.user_id = #{userId}
+            GROUP BY dp.project_id
+            HAVING COUNT(pl.like_id) >= 10
+        )
+    </select>
+
 
 
 </mapper>


### PR DESCRIPTION
## 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

## 📌 이슈 번호
close #137 

## ✨ 반영 브랜치
feat#137-auto-badge -> develop

## 📌 구현 내용 요약

### 🏷️ 뱃지 자동 부여 기능 추가

- 특정 조건을 만족한 유저에게 뱃지를 자동으로 부여하는 로직을 서비스 레이어에 구현했습니다.
- `badge.auto_grant_condition` 값을 기준으로 각 조건에 대한 검증을 진행하며, 조건을 만족할 경우 해당 유저에게 뱃지를 부여합니다.

### ✅ 구현된 자동 부여 조건 목록 (`autoGrantCondition`)
| 조건 코드 | 설명 | 쿼리 |
|-----------|------|------|
| `COMPLETED_FUNDED_PROJECT` | 펀딩 완료된 프로젝트가 있는 경우 | `hasCompletedFundedProject` |
| `ROLE_ADMIN` | 관리자인 경우 | `isAdmin` |
| `DONATED` | 기부 참여 이력이 있는 경우 | `hasDonated` |
| `CHALLENGE_PARTICIPANT` | 챌린지 참여 이력이 있는 경우 | `hasJoinedChallenge` |
| `FINANCIAL_SUBSCRIBER` | 금융상품에 가입한 경우 | `hasSubscribedFinancialProduct` |
| `INFLUENCER` | 내가 작성한 프로젝트에 댓글이 10개 이상 | `hasProjectWithTenOrMoreComments` |
| `COMMENT_MASTER` | 내가 단 댓글이 10개 이상 | `hasPostedTenComments` |
| `HIT_PROJECT_MAKER` | 내가 작성한 프로젝트에 좋아요 10개 이상 | `hasProjectWithTenOrMoreLikes` |
| `VOTE_3_AND_POST_2` | 투표 3회 이상 (예시 기획, 추후 확장 예정) | `votesDAO.countVotesByUserId()` |

### 💡 주요 로직 흐름
1. `badgeDAO.selectAutoGrantBadges()`로 자동 부여 대상 뱃지 목록 조회
2. 각 뱃지별 조건에 따라 자격 여부 판단
3. 해당 유저가 해당 뱃지를 이미 보유하고 있지 않다면 → `user_badge` 테이블에 insert


## 🙏 리뷰 요청 사항

- 현재 조건별 분기 구조(switch-case)가 충분히 확장성 있고 명확한지 피드백 요청드립니다.
- 쿼리 성능에 대해 개선 아이디어가 있다면 코멘트 부탁드립니다.
- 혹시 유저 상태 업데이트와 함께 병렬 처리/이벤트 큐 방식이 더 적합할지 논의하고 싶습니다.

