### PR TITLE
Feat#161 verify ai 인증 기능

### DIFF
--- a/backend_set/src/main/java/org/funding/S3/service/S3ImageService.java
+++ b/backend_set/src/main/java/org/funding/S3/service/S3ImageService.java
@@ -86,5 +86,21 @@ public class S3ImageService {
         return imageUrl.substring(imageUrl.indexOf(".com/") + 5);
     }
 
+    // 이미지 업로드 후 url 추출
+    public String uploadSingleImageAndGetUrl(MultipartFile file) throws IOException {
+        String folder = "challenge/";  // 필요하면 경로 지정
+        String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+        String key = folder + fileName;
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        amazonS3.putObject(new PutObjectRequest(bucketName, key, file.getInputStream(), metadata));
+
+
+        return amazonS3.getUrl(bucketName, key).toString();
+    }
+
 
 }

--- a/backend_set/src/main/java/org/funding/challengeLog/controller/ChallengeLogController.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/controller/ChallengeLogController.java
@@ -1,9 +1,31 @@
 package org.funding.challengeLog.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.funding.challengeLog.service.ChallengeLogService;
+import org.funding.challengeLog.vo.ChallengeLogVO;
+import org.funding.security.util.Auth;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
 @RestController
-@RequestMapping("/challengeLog")
+@RequiredArgsConstructor
+@RequestMapping("/challenge-logs")
 public class ChallengeLogController {
+
+    private final ChallengeLogService challengeLogService;
+
+    @Auth
+    @GetMapping("/{userChallengeId}/all")
+    public ResponseEntity<List<ChallengeLogVO>> getAllLogsByUserChallenge(@PathVariable Long userChallengeId,
+                                                                          HttpServletRequest request) {
+        List<ChallengeLogVO> logs = challengeLogService.getAllLogsByUserChallenge(userChallengeId);
+        return ResponseEntity.ok(logs);
+    }
+
 }

--- a/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Param;
 import org.funding.challengeLog.vo.ChallengeLogVO;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Mapper
 public interface ChallengeLogDAO {
@@ -12,4 +13,11 @@ public interface ChallengeLogDAO {
     void insertChallengeLog(ChallengeLogVO log);
 
     ChallengeLogVO selectLogByUserAndDate(@Param("userChallengeId") Long id, @Param("logDate") LocalDate date);
+
+    List<LocalDate> selectAllLogDatesByUserChallengeId(Long userChallengeId);
+
+    // 중복 방지
+    boolean existsByUserChallengeIdAndLogDate(Long userChallengeId, LocalDate logDate);
+
+
 }

--- a/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
@@ -19,5 +19,6 @@ public interface ChallengeLogDAO {
     // 중복 방지
     boolean existsByUserChallengeIdAndLogDate(Long userChallengeId, LocalDate logDate);
 
+    List<ChallengeLogVO> selectAllLogsByUserChallengeId(Long userChallengeId);
 
 }

--- a/backend_set/src/main/java/org/funding/challengeLog/service/ChallengeLogService.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/service/ChallengeLogService.java
@@ -1,7 +1,21 @@
 package org.funding.challengeLog.service;
 
+import lombok.RequiredArgsConstructor;
+import org.funding.challengeLog.dao.ChallengeLogDAO;
+import org.funding.challengeLog.vo.ChallengeLogVO;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
 public class ChallengeLogService {
+
+    private final ChallengeLogDAO challengeLogDAO;
+
+    // 전체 로그 조회
+    public List<ChallengeLogVO> getAllLogsByUserChallenge(Long userChallengeId) {
+        return challengeLogDAO.selectAllLogsByUserChallengeId(userChallengeId);
+    }
+
 }

--- a/backend_set/src/main/java/org/funding/financialProduct/vo/ChallengeVO.java
+++ b/backend_set/src/main/java/org/funding/financialProduct/vo/ChallengeVO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -16,4 +18,6 @@ public class ChallengeVO {
     private String reward; // 리워드
     private String rewardCondition; // 리워드 조건
     private String verifyStandard; // 첼린지 검증 기준
+    private LocalDate challengeStartDate; // 시작일
+    private LocalDate challengeEndDate; // 종료일
 }

--- a/backend_set/src/main/java/org/funding/fund/dto/FundProductRequestDTO.java
+++ b/backend_set/src/main/java/org/funding/fund/dto/FundProductRequestDTO.java
@@ -98,6 +98,8 @@ public class FundProductRequestDTO {
         private String reward;
         private String rewardCondition;
         private String verifyStandard; // 첼린지 검증 기준
+        private LocalDate challengeStartDate;
+        private LocalDate challengeEndDate;
         
         // Fund 생성 필드
         private Long projectId;

--- a/backend_set/src/main/java/org/funding/fund/service/FundService.java
+++ b/backend_set/src/main/java/org/funding/fund/service/FundService.java
@@ -252,6 +252,8 @@ public class FundService {
                 .reward(request.getReward())
                 .rewardCondition(request.getRewardCondition())
                     .verifyStandard(request.getVerifyStandard()) // 검증 기준 추가
+                    .challengeStartDate(request.getChallengeStartDate())
+                    .challengeEndDate(request.getChallengeEndDate())
                 .build();
             
             challengeDAO.insertChallenge(challenge);

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
@@ -1,15 +1,21 @@
 package org.funding.userChallenge.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.funding.S3.service.S3ImageService;
 import org.funding.security.util.Auth;
 import org.funding.userChallenge.dto.ApplyChallengeRequestDTO;
 import org.funding.userChallenge.dto.ChallengeRequestDTO;
 import org.funding.userChallenge.dto.DeleteChallengeRequestDTO;
 import org.funding.userChallenge.service.UserChallengeService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/userChallenge")
@@ -17,6 +23,7 @@ import javax.servlet.http.HttpServletRequest;
 public class UserChallengeController {
 
     private final UserChallengeService userChallengeService;
+    private final S3ImageService s3ImageService;
 
     // 첼린지 가입 신청 로직
     @Auth
@@ -40,12 +47,14 @@ public class UserChallengeController {
 
     // 첼린지 인증 로직
     @Auth
-    @PostMapping("/{id}/verify")
+    @PostMapping(value = "/{id}/verify", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> verifyChallenge(@PathVariable("id") Long id,
-                                             @RequestBody ChallengeRequestDTO challengeRequestDTO,
-                                             HttpServletRequest request) {
+                                             @RequestPart("file") MultipartFile file,
+                                             @RequestPart("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+                                             HttpServletRequest request) throws IOException {
         Long userId = (Long) request.getAttribute("userId");
-        userChallengeService.verifyDailyChallenge(id, userId, challengeRequestDTO.getImageUrl(), challengeRequestDTO.getDate());
+        String imageUrl = s3ImageService.uploadSingleImageAndGetUrl(file);
+        userChallengeService.verifyDailyChallenge(id, userId, imageUrl, date);
         return ResponseEntity.ok("인증 완료");
     }
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
@@ -25,4 +25,5 @@ public interface UserChallengeDAO {
 
     // 유저 챌린지 참여 취소
     void deleteUserChallenge(@Param("userChallengeId") Long id);
+
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
@@ -22,6 +22,11 @@ import org.funding.userChallenge.vo.UserChallengeVO;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -78,54 +83,80 @@ public class UserChallengeService {
     // 첼린지 인증 로직
     public void verifyDailyChallenge(Long userChallengeId, Long userId, String imageUrl, LocalDate logDate) {
 
-        // 펀딩 진행 예외처리
+        // 1. 챌린지, 펀딩, 상품 조회
         UserChallengeVO userChallenge = userChallengeDAO.findById(userChallengeId);
-        Long fundId = userChallenge.getFundId();
-        FundVO fund = fundDAO.selectById(fundId);
-        ProgressType type = fund.getProgress();
-        Long productId = fund.getProductId();
-        FinancialProductVO product = financialProductDAO.selectById(productId);
+        FundVO fund = fundDAO.selectById(userChallenge.getFundId());
+        ChallengeVO challenge = challengeDAO.selectByProductId(fund.getProductId());
 
-        // 상품 예외처리
+        LocalDate startDate = challenge.getChallengeStartDate();
+        LocalDate endDate = challenge.getChallengeEndDate();
+
+        // 2. 날짜 예외처리 (로그 날짜 기준으로)
+        if (logDate.isBefore(startDate) || logDate.isAfter(endDate)) {
+            throw new RuntimeException("챌린지 참여 가능 날짜가 아닙니다.");
+        }
+
+        // 3. 중복 인증 예외처리
+        ChallengeLogVO existing = challengeLogDAO.selectLogByUserAndDate(userChallengeId, logDate);
+        if (existing != null) {
+            throw new RuntimeException("해당 날짜는 이미 인증되었습니다.");
+        }
+
+        // 4. 챌린지 가입 여부 확인
+        boolean isVerify = userChallengeDAO.existsByIdAndUserId(userChallengeId, userId);
+        if (!isVerify) {
+            throw new RuntimeException("해당 유저는 첼린지에 가입되어 있지 않습니다.");
+        }
+
+        // 5. 펀딩 상태 및 상품 유효성 체크
+        ProgressType type = fund.getProgress();
+        FinancialProductVO product = financialProductDAO.selectById(fund.getProductId());
+
         if (product == null) {
             throw new RuntimeException("해당 상품은 존재하지 않습니다.");
         }
 
-        // 펀딩 예외처리
         if (type != ProgressType.Launch) {
-            throw new RuntimeException("해당 펀딩은 종료된 펀딩입니다");
+            throw new RuntimeException("해당 펀딩은 종료된 상태입니다.");
         }
 
-        // 유형 예외처리
-        FundType fundType = product.getFundType();
-        if (fundType != FundType.Challenge) {
+        if (product.getFundType() != FundType.Challenge) {
             throw new RuntimeException("해당 상품은 첼린지 상품이 아닙니다.");
         }
 
-        // 중복 예외처리
-        ChallengeLogVO existing = challengeLogDAO.selectLogByUserAndDate(userChallengeId, logDate);
-        if (existing != null) {
-            throw new RuntimeException("금일은 이미 인증 되었습니다");
+        // 6. 미인증 로그 자동 생성 (오늘 이전까지)
+        LocalDate today = LocalDate.now();
+        LocalDate lastDate = today.isBefore(endDate) ? today : endDate;
+
+        List<LocalDate> allDates = startDate.datesUntil(lastDate.plusDays(1)).collect(Collectors.toList());
+        List<LocalDate> verifyDates = challengeLogDAO.selectAllLogDatesByUserChallengeId(userChallengeId);
+        Set<LocalDate> verifiedSet = new HashSet<>(verifyDates);
+
+        for (LocalDate date : allDates) {
+            if (!verifiedSet.contains(date)) {
+                boolean exists = challengeLogDAO.existsByUserChallengeIdAndLogDate(userChallengeId, date);
+                if (!exists) {
+                    ChallengeLogVO log = new ChallengeLogVO();
+                    log.setUserChallengeId(userChallengeId);
+                    log.setLogDate(date);
+                    log.setVerified(false);
+                    log.setVerifiedResult("미인증");
+                    log.setImageUrl(null);
+                    challengeLogDAO.insertChallengeLog(log);
+                }
+            }
         }
 
-        ChallengeVO challenge = challengeDAO.selectByProductId(product.getProductId());
-        // 검증 기준
+        // 7. 이미지 분석 및 인증 검증
         String rewardCondition = challenge.getRewardCondition();
-
-        // 해당 사용자가 첼린지에 가입이 되어있는지
-        boolean isVerify = userChallengeDAO.existsByIdAndUserId(userChallengeId, userId);
-        if (!isVerify) {
-            throw new RuntimeException("해당 유저는 첼린지에 가입되어있지 않습니다.");
-        }
-
         String result = openAIVisionClient.analyzeImageWithPrompt(imageUrl, rewardCondition);
         boolean isVerified = result.contains("확인되었습니다.");
 
-        // 인증 예외처리
         if (!isVerified) {
-            throw new RuntimeException("해당 사진이 리워드 조건 기준에 도달하지 못하였습니다.");
+            throw new RuntimeException("해당 사진이 리워드 조건을 만족하지 못했습니다.");
         }
 
+        // 8. 인증 성공 로그 저장
         ChallengeLogVO log = new ChallengeLogVO();
         log.setUserChallengeId(userChallengeId);
         log.setLogDate(logDate);
@@ -134,8 +165,11 @@ public class UserChallengeService {
         log.setVerifiedResult(result);
         challengeLogDAO.insertChallengeLog(log);
 
+        // 9. 유저 챌린지 상태 업데이트
         userChallengeDAO.updateUserChallengeSuccess(userChallengeId);
     }
+
+
 
     // 챌린지 취소 로직
     public void deleteChallenge(Long userChallengeId, Long userId) {

--- a/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
+++ b/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
@@ -27,6 +27,13 @@
         SELECT log_date FROM challenge_log WHERE user_challenge_id = #{userChallengeId} AND verified = true
     </select>
 
+    <select id="selectAllLogsByUserChallengeId" resultType="org.funding.challengeLog.vo.ChallengeLogVO">
+        SELECT *
+        FROM challenge_log
+        WHERE user_challenge_id = #{userChallengeId}
+        ORDER BY log_date ASC
+    </select>
+
     <select id="existsByUserChallengeIdAndLogDate" resultType="boolean">
         SELECT EXISTS (
             SELECT 1

--- a/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
+++ b/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
@@ -23,5 +23,18 @@
           AND log_date = #{logDate}
     </select>
 
+    <select id="selectAllLogDatesByUserChallengeId" resultType="java.time.LocalDate">
+        SELECT log_date FROM challenge_log WHERE user_challenge_id = #{userChallengeId} AND verified = true
+    </select>
+
+    <select id="existsByUserChallengeIdAndLogDate" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1
+            FROM challenge_log
+            WHERE user_challenge_id = #{userChallengeId}
+              AND log_date = #{logDate}
+        )
+    </select>
+
 
 </mapper>


### PR DESCRIPTION
📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
 기능 추가

📌 이슈 번호
close #161 

✨ 반영 브랜치
feat#161-verify-ai → develop

📌 주요 변경 사항
사용자 인증 기반으로 챌린지 인증 기능 구현 (@Auth, HttpServletRequest)
인증 이미지 업로드 처리 (S3 업로드 후 URL 저장)
인증 일자별 챌린지 로그 생성 (ChallengeLogVO)
중복 인증 방지 및 챌린지 기간 체크 로직 추가
종료일이 지났으면 "날짜가 지났습니다" 예외 발생
동일 날짜 인증 로그가 이미 있으면 예외 처리
ChallengeLogDAO 및 MyBatis XML로 인증 로그 리스트 조회 기능 추가 (날짜 기준 오름차순)
날짜 형식 @RequestPart로 LocalDate 파싱 처리

✅ 기능 흐름 요약
@PostMapping("/{id}/verify") API에서 이미지(MultipartFile)와 날짜(LocalDate)를 @RequestPart로 전달
이미지 파일을 S3에 업로드하여 URL 생성
유저 ID와 인증 날짜를 바탕으로 로그 중복 여부 및 챌린지 종료일 검증
이상 없을 시 ChallengeLog 엔티티 생성 및 DB에 저장
/logs API로 유저의 인증 기록을 날짜순 정렬하여 조회 가능


🙏 리뷰 요청 사항
인증 예외 처리 방식에 대한 피드백
DAO + MyBatis XML 방식에서 성능/가독성 개선 여지
verifyChallenge() 흐름이 자연스러운지 확인 부탁드립니다

