### PR TITLE
Feat#185 flow api 2(내가 참여한 펀딩 상품 조회 api 개발)

### DIFF
--- a/backend_set/src/main/java/org/funding/financialProduct/dao/LoanDAO.java
+++ b/backend_set/src/main/java/org/funding/financialProduct/dao/LoanDAO.java
@@ -3,10 +3,13 @@ package org.funding.financialProduct.dao;
 import org.apache.ibatis.annotations.Mapper;
 import org.funding.financialProduct.vo.LoanVO;
 
+import java.util.List;
+
 @Mapper
 public interface LoanDAO {
     void insertLoan(LoanVO vo);
     LoanVO selectByProductId(Long productId);
     void update(LoanVO vo);
     void deleteByProductId(Long productId);
+
 }

--- a/backend_set/src/main/java/org/funding/fund/controller/FundController.java
+++ b/backend_set/src/main/java/org/funding/fund/controller/FundController.java
@@ -203,6 +203,7 @@ public class FundController {
     }
     
     /**
+     *
      * 펀딩 삭제
      * DELETE /api/fund/{fundId}
      * fund_id로 펀딩과 관련된 모든 데이터를 삭제
@@ -216,4 +217,7 @@ public class FundController {
         String result = fundService.deleteFund(fundId, userId);
         return ResponseEntity.ok(Map.of("message", result));
     }
+
+
+
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @RestController
-@RequestMapping("/userChallenge")
+@RequestMapping("/user-challenge")
 @RequiredArgsConstructor
 public class UserChallengeController {
 
@@ -60,7 +60,7 @@ public class UserChallengeController {
 
     // 유저가 참여한 모든 챌린지 조회
     @Auth
-    @GetMapping("/all")
+    @GetMapping("/user/all/v2")
     public ResponseEntity<?> getAllMyChallenges(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         // userId가 없는 경우 예외 처리 (필요 시)

--- a/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
+++ b/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @RestController
-@RequestMapping("/user-saving")
+@RequestMapping("/user-donation")
 @RequiredArgsConstructor
 public class UserDonationController {
 
@@ -66,7 +66,7 @@ public class UserDonationController {
 
     // 내가 참여한 기부 내역 조회
     @Auth
-    @GetMapping
+    @GetMapping("/user/all/v2")
     public ResponseEntity<?> getMyAllDonations(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         if (userId == null) {

--- a/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
+++ b/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.funding.security.util.Auth;
 import org.funding.userDonation.dto.DonateRequestDTO;
 import org.funding.userDonation.dto.DonateResponseDTO;
+import org.funding.userDonation.dto.UserDonationDetailDTO;
 import org.funding.userDonation.service.UserDonationService;
 import org.funding.userDonation.vo.UserDonationVO;
 import org.springframework.http.ResponseEntity;
@@ -61,5 +62,19 @@ public class UserDonationController {
                                                  HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         return ResponseEntity.ok(userDonationService.deleteDonation(id, userId));
+    }
+
+    // 내가 참여한 기부 내역 조회
+    @Auth
+    @GetMapping
+    public ResponseEntity<?> getMyAllDonations(HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
+        if (userId == null) {
+            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+        }
+
+        List<UserDonationDetailDTO> myDonations = userDonationService.findMyDonations(userId);
+
+        return ResponseEntity.ok(myDonations);
     }
 }

--- a/backend_set/src/main/java/org/funding/userDonation/dao/UserDonationDAO.java
+++ b/backend_set/src/main/java/org/funding/userDonation/dao/UserDonationDAO.java
@@ -2,6 +2,7 @@ package org.funding.userDonation.dao;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.funding.userDonation.dto.UserDonationDetailDTO;
 import org.funding.userDonation.vo.UserDonationVO;
 
 import java.util.List;
@@ -25,4 +26,6 @@ public interface UserDonationDAO {
 
     // 유저 참여했는지 판별
     boolean existsByUserIdAndFundId(@Param("userId") Long userId, @Param("fundId") Long fundId);
+
+    List<UserDonationDetailDTO> findAllDonationDetailsByUserId(@Param("userId") Long userId);
 }

--- a/backend_set/src/main/java/org/funding/userDonation/dto/UserDonationDetailDTO.java
+++ b/backend_set/src/main/java/org/funding/userDonation/dto/UserDonationDetailDTO.java
@@ -1,0 +1,15 @@
+package org.funding.userDonation.dto;
+
+import lombok.Data;
+
+@Data
+public class UserDonationDetailDTO {
+    private Long userDonationId;
+    private Integer donationAmount;
+    private boolean anonymous;
+
+    private String donationName;
+    private String recipient;
+    private Long targetAmount;
+    private String donationImageUrl;
+}

--- a/backend_set/src/main/java/org/funding/userDonation/service/UserDonationService.java
+++ b/backend_set/src/main/java/org/funding/userDonation/service/UserDonationService.java
@@ -13,6 +13,7 @@ import org.funding.user.vo.enumType.Role;
 import org.funding.userDonation.dao.UserDonationDAO;
 import org.funding.userDonation.dto.DonateRequestDTO;
 import org.funding.userDonation.dto.DonateResponseDTO;
+import org.funding.userDonation.dto.UserDonationDetailDTO;
 import org.funding.userDonation.vo.UserDonationVO;
 import org.springframework.stereotype.Service;
 
@@ -139,6 +140,10 @@ public class UserDonationService {
             throw new RuntimeException("해당 기부는 종료되었습니다.");
         }
         return fund;
+    }
+
+    public List<UserDonationDetailDTO> findMyDonations(Long userId) {
+        return userDonationDAO.findAllDonationDetailsByUserId(userId);
     }
 
 }

--- a/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
+++ b/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
@@ -64,9 +64,9 @@ public class UserLoanController {
         return ResponseEntity.ok(userLoanService.processLoanPayment(approveUserLoanRequestDTO, userId));
     }
 
-    // 유저가 가입한 모든 대출
+    // 유저가 가입한 모든 대출 조회
     @Auth
-    @GetMapping
+    @GetMapping("/user/all/v2")
     public ResponseEntity<?> getMyAllLoans(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         if (userId == null) {

--- a/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
+++ b/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
@@ -2,15 +2,13 @@ package org.funding.userLoan.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.funding.security.util.Auth;
-import org.funding.userLoan.dto.ApproveUserLoanRequestDTO;
-import org.funding.userLoan.dto.CancelLoanRequestDTO;
-import org.funding.userLoan.dto.UserLoanRequestDTO;
-import org.funding.userLoan.dto.UserLoanResponseDTO;
+import org.funding.userLoan.dto.*;
 import org.funding.userLoan.service.UserLoanService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 @RestController
 @RequestMapping("/user-loan")
@@ -66,13 +64,16 @@ public class UserLoanController {
         return ResponseEntity.ok(userLoanService.processLoanPayment(approveUserLoanRequestDTO, userId));
     }
 
-    // 유저가 신청한 대출 내역
+    // 유저가 가입한 모든 대출
     @Auth
-    @GetMapping("/users/loan")
-    public ResponseEntity<?> getUserLoan(HttpServletRequest request) {
+    @GetMapping
+    public ResponseEntity<?> getMyAllLoans(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
-
+        if (userId == null) {
+            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+        }
+        List<UserLoanDetailDTO> myLoans = userLoanService.getAllUserLoans(userId);
+        return ResponseEntity.ok(myLoans);
     }
-
 
 }

--- a/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
+++ b/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
@@ -66,5 +66,13 @@ public class UserLoanController {
         return ResponseEntity.ok(userLoanService.processLoanPayment(approveUserLoanRequestDTO, userId));
     }
 
+    // 유저가 신청한 대출 내역
+    @Auth
+    @GetMapping("/users/loan")
+    public ResponseEntity<?> getUserLoan(HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
+
+    }
+
 
 }

--- a/backend_set/src/main/java/org/funding/userLoan/dao/UserLoanDAO.java
+++ b/backend_set/src/main/java/org/funding/userLoan/dao/UserLoanDAO.java
@@ -2,6 +2,7 @@ package org.funding.userLoan.dao;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.funding.userLoan.dto.UserLoanDetailDTO;
 import org.funding.userLoan.dto.UserLoanRequestDTO;
 import org.funding.userLoan.vo.UserLoanVO;
 import org.funding.userLoan.vo.enumType.SuccessType;
@@ -30,4 +31,6 @@ public interface UserLoanDAO {
 
     // 유저 참여했는지 판별
     boolean existsByUserIdAndFundId(@Param("userId") Long userId, @Param("fundId") Long fundId);
+
+    List<UserLoanDetailDTO> findAllLoanDetailsByUserId(@Param("userId") Long userId);
 }

--- a/backend_set/src/main/java/org/funding/userLoan/dto/UserLoanDetailDTO.java
+++ b/backend_set/src/main/java/org/funding/userLoan/dto/UserLoanDetailDTO.java
@@ -1,0 +1,22 @@
+package org.funding.userLoan.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class UserLoanDetailDTO {
+    // 내 대출 정보 (from user_loan)
+    private Long userLoanId;
+    private Integer loanAmount;
+    private boolean fullPayment;
+    private String loanAccess; // SuccessType은 String으로 변환하여 전달
+
+    // 대출 상품 정보 (from loan, financial_product)
+    private String loanName; // 상품 이름
+    private Long loanLimit;
+    private Double minInterestRate;
+    private Double maxInterestRate;
+    private LocalDateTime repaymentStartDate;
+    private LocalDateTime repaymentEndDate;
+}

--- a/backend_set/src/main/java/org/funding/userLoan/service/UserLoanService.java
+++ b/backend_set/src/main/java/org/funding/userLoan/service/UserLoanService.java
@@ -12,10 +12,7 @@ import org.funding.user.dao.MemberDAO;
 import org.funding.user.vo.MemberVO;
 import org.funding.user.vo.enumType.Role;
 import org.funding.userLoan.dao.UserLoanDAO;
-import org.funding.userLoan.dto.ApproveUserLoanRequestDTO;
-import org.funding.userLoan.dto.CancelLoanRequestDTO;
-import org.funding.userLoan.dto.UserLoanRequestDTO;
-import org.funding.userLoan.dto.UserLoanResponseDTO;
+import org.funding.userLoan.dto.*;
 import org.funding.userLoan.vo.UserLoanVO;
 import org.funding.userLoan.vo.enumType.SuccessType;
 import org.springframework.http.ResponseEntity;
@@ -161,8 +158,8 @@ public class UserLoanService {
     }
 
     // 유저가 가입한 대출 모아보기
-    public List<UserLoanVO> getAllUserLoans(Long userId) {
-        return loanDAO.selectByUserId(userId);
+    public List<UserLoanDetailDTO> getAllUserLoans(Long userId) {
+        return userLoanDAO.findAllLoanDetailsByUserId(userId);
     }
 
     // 공통 검증 메서드

--- a/backend_set/src/main/java/org/funding/userLoan/service/UserLoanService.java
+++ b/backend_set/src/main/java/org/funding/userLoan/service/UserLoanService.java
@@ -21,6 +21,8 @@ import org.funding.userLoan.vo.enumType.SuccessType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserLoanService {
@@ -156,6 +158,11 @@ public class UserLoanService {
         userLoan.setLoanAccess(SuccessType.DONE);
         userLoanDAO.updateUserLoan(userLoan);
         return "지급 완료";
+    }
+
+    // 유저가 가입한 대출 모아보기
+    public List<UserLoanVO> getAllUserLoans(Long userId) {
+        return loanDAO.selectByUserId(userId);
     }
 
     // 공통 검증 메서드

--- a/backend_set/src/main/java/org/funding/userSaving/controller/UserSavingController.java
+++ b/backend_set/src/main/java/org/funding/userSaving/controller/UserSavingController.java
@@ -2,6 +2,7 @@ package org.funding.userSaving.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.funding.security.util.Auth;
+import org.funding.userSaving.dto.UserSavingDetailDTO;
 import org.funding.userSaving.dto.UserSavingRequestDTO;
 import org.funding.userSaving.service.UserSavingService;
 import org.funding.userSaving.vo.UserSavingVO;
@@ -44,11 +45,23 @@ public class UserSavingController {
         return ResponseEntity.ok(userSavingService.findById(id));
     }
 
-    // 유저가 가입한 저축 상품 전체 조회
+    // 유저가 가입한 저축 상품 전체 조회 (디테일적이지않음 사용 x)
     @Auth
     @GetMapping("/user")
     public ResponseEntity<List<UserSavingVO>> getAllUserSaving(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         return ResponseEntity.ok(userSavingService.getAllUserSaving(userId));
+    }
+
+    // 유저가 가입한 저축 상품 모아보기
+    @Auth
+    @GetMapping
+    public ResponseEntity<?> getMyAllSavings(HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
+        if (userId == null) {
+            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+        }
+        List<UserSavingDetailDTO> mySavings = userSavingService.findMySavings(userId);
+        return ResponseEntity.ok(mySavings);
     }
 }

--- a/backend_set/src/main/java/org/funding/userSaving/controller/UserSavingController.java
+++ b/backend_set/src/main/java/org/funding/userSaving/controller/UserSavingController.java
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @RestController
-@RequestMapping("/userSaving")
+@RequestMapping("/user-saving")
 @RequiredArgsConstructor
 public class UserSavingController {
 
@@ -55,7 +55,7 @@ public class UserSavingController {
 
     // 유저가 가입한 저축 상품 모아보기
     @Auth
-    @GetMapping
+    @GetMapping("/user/all/v2")
     public ResponseEntity<?> getMyAllSavings(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         if (userId == null) {

--- a/backend_set/src/main/java/org/funding/userSaving/dao/UserSavingDAO.java
+++ b/backend_set/src/main/java/org/funding/userSaving/dao/UserSavingDAO.java
@@ -2,6 +2,7 @@ package org.funding.userSaving.dao;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.funding.userSaving.dto.UserSavingDetailDTO;
 import org.funding.userSaving.vo.UserSavingVO;
 
 import java.util.List;
@@ -25,4 +26,8 @@ public interface UserSavingDAO {
 
     // 유저 참여했는지 판별
     boolean existsByUserIdAndFundId(@Param("userId") Long userId, @Param("fundId") Long fundId);
+
+    // 사용자가 가입한 모든 저축 목록 조회
+    List<UserSavingDetailDTO> findAllSavingDetailsByUserId(@Param("userId") Long userId);
+
 }

--- a/backend_set/src/main/java/org/funding/userSaving/dto/UserSavingDetailDTO.java
+++ b/backend_set/src/main/java/org/funding/userSaving/dto/UserSavingDetailDTO.java
@@ -1,0 +1,15 @@
+package org.funding.userSaving.dto;
+
+import lombok.Data;
+
+@Data
+public class UserSavingDetailDTO {
+
+    private Long userSavingId;
+    private Integer savingAmount;
+
+    private String savingName;
+    private Integer periodDays;
+    private Double interestRate;
+    private String savingImageUrl;
+}

--- a/backend_set/src/main/java/org/funding/userSaving/service/UserSavingService.java
+++ b/backend_set/src/main/java/org/funding/userSaving/service/UserSavingService.java
@@ -5,6 +5,7 @@ import org.funding.badge.service.BadgeService;
 import org.funding.user.dao.MemberDAO;
 import org.funding.user.vo.MemberVO;
 import org.funding.userSaving.dao.UserSavingDAO;
+import org.funding.userSaving.dto.UserSavingDetailDTO;
 import org.funding.userSaving.dto.UserSavingRequestDTO;
 import org.funding.userSaving.vo.UserSavingVO;
 import org.springframework.stereotype.Service;
@@ -65,5 +66,10 @@ public class UserSavingService {
     // 유저가 가입한 저축 상품 전체 보기
     public List<UserSavingVO> getAllUserSaving(Long userId) {
         return userSavingDAO.findByUserId(userId);
+    }
+
+    // 유저가 가입한 저축 상품 모아보기(디테일)
+    public List<UserSavingDetailDTO> findMySavings(Long userId) {
+        return userSavingDAO.findAllSavingDetailsByUserId(userId);
     }
 }

--- a/backend_set/src/main/resources/org/funding/financialProduct/dao/LoanDAO.xml
+++ b/backend_set/src/main/resources/org/funding/financialProduct/dao/LoanDAO.xml
@@ -81,4 +81,6 @@
         ORDER BY installment_id DESC
     </select>
 
+
+
 </mapper>

--- a/backend_set/src/main/resources/org/funding/userDonation/dao/UserDonationDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userDonation/dao/UserDonationDAO.xml
@@ -68,4 +68,31 @@
         WHERE user_id = #{userId} AND fund_id = #{fundId}
     </select>
 
+    <select id="findAllDonationDetailsByUserId" resultType="org.funding.userDonation.dto.UserDonationDetailDTO">
+        SELECT
+            ud.user_donation_id AS userDonationId,
+            ud.donation_amount AS donationAmount,
+            ud.anonymous AS anonymous,
+            p.name AS donationName,
+            d.recipient AS recipient,
+            d.target_amount AS targetAmount,
+            (SELECT image_url FROM Image
+             WHERE postId = p.product_id
+               AND image_type = 'Funding'
+             ORDER BY image_id ASC LIMIT 1) AS donationImageUrl
+
+        FROM
+            user_donation ud
+            JOIN
+            fund f ON ud.fund_id = f.fund_id
+            JOIN
+            donation d ON f.product_id = d.product_id
+            JOIN
+            financial_product p ON d.product_id = p.product_id
+        WHERE
+            ud.user_id = #{userId}
+        ORDER BY
+            ud.user_donation_id DESC
+    </select>
+
 </mapper>

--- a/backend_set/src/main/resources/org/funding/userDonation/dao/UserDonationDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userDonation/dao/UserDonationDAO.xml
@@ -76,8 +76,8 @@
             p.name AS donationName,
             d.recipient AS recipient,
             d.target_amount AS targetAmount,
-            (SELECT image_url FROM Image
-             WHERE postId = p.product_id
+            (SELECT image_url FROM image
+             WHERE post_id = p.product_id
                AND image_type = 'Funding'
              ORDER BY image_id ASC LIMIT 1) AS donationImageUrl
 

--- a/backend_set/src/main/resources/org/funding/userLoan/dao/UserLoanDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userLoan/dao/UserLoanDAO.xml
@@ -54,4 +54,31 @@
         WHERE user_id = #{userId} AND fund_id = #{fundId}
     </select>
 
+    <select id="findAllLoanDetailsByUserId" resultType="org.funding.userLoan.dto.UserLoanDetailDTO">
+        SELECT
+            ul.user_loan_id AS userLoanId,
+            ul.loan_amount AS loanAmount,
+            ul.full_payment AS fullPayment,
+            ul.loan_access AS loanAccess,
+            p.name AS loanName,
+            l.loan_limit AS loanLimit,
+            l.min_interest_rate AS minInterestRate,
+            l.max_interest_rate AS maxInterestRate,
+            l.repayment_start_date AS repaymentStartDate,
+            l.repayment_end_date AS repaymentEndDate
+        FROM
+            user_loan ul
+                JOIN
+            fund f ON ul.fund_id = f.fund_id
+                JOIN
+            loan l ON f.product_id = l.product_id
+                JOIN
+            financial_product p ON l.product_id = p.product_id
+        WHERE
+            ul.user_id = #{userId}
+        ORDER BY
+            ul.user_loan_id DESC
+    </select>
+
+
 </mapper>

--- a/backend_set/src/main/resources/org/funding/userSaving/dao/UserSavingDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userSaving/dao/UserSavingDAO.xml
@@ -57,7 +57,7 @@
             s.period_days AS periodDays,
             s.interest_rate AS interestRate,
             (SELECT image_url FROM image
-             WHERE postId = p.product_id
+             WHERE post_id = p.product_id
                AND image_type = 'Funding'
              ORDER BY image_id ASC LIMIT 1) AS savingImageUrl
         FROM

--- a/backend_set/src/main/resources/org/funding/userSaving/dao/UserSavingDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userSaving/dao/UserSavingDAO.xml
@@ -47,4 +47,31 @@
         WHERE user_id = #{userId} AND fund_id = #{fundId}
     </select>
 
+
+<!--    사용자가 가입한 저축 내용 조회-->
+    <select id="findAllSavingDetailsByUserId" resultType="org.funding.userSaving.dto.UserSavingDetailDTO">
+        SELECT
+            us.user_saving_id AS userSavingId,
+            us.saving_amount AS savingAmount,
+            p.name AS savingName,
+            s.period_days AS periodDays,
+            s.interest_rate AS interestRate,
+            (SELECT image_url FROM image
+             WHERE postId = p.product_id
+               AND image_type = 'Funding'
+             ORDER BY image_id ASC LIMIT 1) AS savingImageUrl
+        FROM
+            user_saving us
+            JOIN
+            fund f ON us.fund_id = f.fund_id
+            JOIN
+            savings s ON f.product_id = s.product_id
+            JOIN
+            financial_product p ON s.product_id = p.product_id
+        WHERE
+            us.user_id = #{userId}
+        ORDER BY
+            us.user_saving_id DESC
+    </select>
+
 </mapper>


### PR DESCRIPTION

📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
[x] 기능 추가
[ ] 기능 삭제
[ ] 버그 수정
[ ] 코드 리팩토링
[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
[ ] 코드에 영향을 주지 않는 변경사항 (ex. 오타 수정, 탭 사이즈 변경, 변수명 변경)

📌 이슈 번호
close #185 

✨ 반영 브랜치
feat#185-flow-api-2 -> develop

✨ PR 개요
로그인한 사용자가 '마이페이지' 등에서 본인이 참여한 펀딩 상품 목록을 종류별로 조회할 수 있는 API를 구현했습니다.
이번 작업을 통해 클라이언트는 사용자의 참여 이력을 기반으로 한 동적인 화면을 구성할 수 있습니다. 구현된 API 엔드포인트는 다음과 같습니다.

GET /api/my-challenges : 참여한 모든 챌린지 목록 조회
GET /api/my-donations : 참여한 모든 기부 목록 조회
GET /api/my-loans : 실행한 모든 대출 목록 조회
GET /api/y-savings : 가입한 모든 저축 목록 조회

💻 작업 내용
1. 각 펀딩 타입별 목록 조회 기능 구현
UserChallenge, UserDonation, UserLoan, UserSaving 각 도메인에 대해 Controller, Service, DAO 계층을 구현하여 API를 개발했습니다.

2. 전용 DTO(Data Transfer Object) 설계
API 응답 데이터의 형태를 명확히 하고 불필요한 정보 노출을 방지하기 위해, 각 기능에 맞는 DTO(UserChallengeDetailDTO, UserDonationDetailDTO 등)를 설계하여 사용했습니다.

3. MyBatis JOIN 쿼리를 통한 데이터 통합 조회
사용자의 참여 정보(user_... 테이블)와 상품의 상세 정보(fund, challenge, financial_product 등)를 한 번에 효율적으로 가져오기 위해 MyBatis XML 매퍼에 JOIN을 적극적으로 활용했습니다.

4. 대표 이미지 조회 로직 최적화 (서브쿼리 사용)
하나의 상품에 여러 이미지가 존재할 경우, 목록 조회 시 결과가 중복되는 문제를 해결하기 위해 LEFT JOIN 대신 SELECT 절 서브쿼리와 LIMIT 1을 사용했습니다. 이를 통해 각 항목마다 하나의 대표 이미지만을 안정적으로 가져오도록 구현했습니다.

🙏 리뷰 요청 사항
쿼리 효율성 검토: 여러 테이블을 JOIN하고 서브쿼리를 사용하는 과정에서 비효율적인 부분이 없는지 검토 부탁드립니다. 특히, 데이터가 많아질 경우를 대비한 인덱스 활용 방안이나 더 나은 쿼리 구조에 대한 의견을 주시면 감사하겠습니다.
API 경로 및 네이밍 컨벤션: 새롭게 추가된 API 엔드포인트(/api/my-challenges 등)와 DTO의 이름이 저희 팀의 컨벤션에 잘 맞는지 확인 부탁드립니다.
응답 데이터 구조: 현재 DTO가 클라이언트에서 필요한 정보를 충분히 담고 있는지, 혹은 불필요한 정보가 포함되어 있지는 않은지 검토해주시면 좋겠습니다.