### PR TITLE
feat: 내가 생성한 프로젝트 조회 기능

### DIFF
--- a/backend_set/.idea/dataSources.xml
+++ b/backend_set/.idea/dataSources.xml
@@ -26,7 +26,7 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
-    <data-source source="LOCAL" name="FunzyProject@138.2.112.157" uuid="c222b042-5665-4a10-93f6-8d535e3baa76">
+    <data-source source="LOCAL" name="FunzyProject" uuid="c222b042-5665-4a10-93f6-8d535e3baa76">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>

--- a/backend_set/src/main/java/org/funding/fund/controller/FundController.java
+++ b/backend_set/src/main/java/org/funding/fund/controller/FundController.java
@@ -1,10 +1,7 @@
 package org.funding.fund.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.funding.fund.dto.FundProductRequestDTO;
-import org.funding.fund.dto.FundListResponseDTO;
-import org.funding.fund.dto.FundDetailResponseDTO;
-import org.funding.fund.dto.FundUpdateRequestDTO;
+import org.funding.fund.dto.*;
 import org.funding.fund.service.FundService;
 import org.funding.fund.vo.FundVO;
 import org.funding.fund.vo.enumType.FundType;
@@ -218,6 +215,19 @@ public class FundController {
         return ResponseEntity.ok(Map.of("message", result));
     }
 
+
+    // 유저가 생성한 프로젝트 조회
+    @Auth
+    @GetMapping("/my/fund/all")
+    public ResponseEntity<?> getMyAllCreatedFunds(HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
+        if (userId == null) {
+            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+        }
+        List<MyFundDetailDTO> myFunds = fundService.findMyCreatedFunds(userId);
+
+        return ResponseEntity.ok(myFunds);
+    }
 
 
 }

--- a/backend_set/src/main/java/org/funding/fund/dao/FundDAO.java
+++ b/backend_set/src/main/java/org/funding/fund/dao/FundDAO.java
@@ -2,6 +2,7 @@ package org.funding.fund.dao;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.funding.fund.dto.MyFundDetailDTO;
 import org.funding.fund.vo.FundVO;
 import org.funding.fund.vo.enumType.ProgressType;
 import org.funding.fund.vo.enumType.FundType;
@@ -33,5 +34,8 @@ public interface FundDAO {
     
     // 펀딩 상세 조회 by ID
     FundDetailResponseDTO selectDetailById(Long fundId);
+
+    // 유저가 업로드한 펀딩 보기
+    List<MyFundDetailDTO> findAllByUploaderId(@Param("uploaderId") Long uploaderId);
   
 }

--- a/backend_set/src/main/java/org/funding/fund/dto/MyFundDetailDTO.java
+++ b/backend_set/src/main/java/org/funding/fund/dto/MyFundDetailDTO.java
@@ -1,0 +1,21 @@
+package org.funding.fund.dto;
+
+import lombok.Data;
+import org.funding.fund.vo.enumType.FundType;
+import org.funding.fund.vo.enumType.ProgressType;
+
+import java.time.LocalDateTime;
+
+@Data
+public class MyFundDetailDTO {
+    private Long fundId;
+    private ProgressType progress;
+    private LocalDateTime launchAt;
+    private LocalDateTime endAt;
+    private String financialInstitution;
+
+    private String productName;
+    private FundType fundType;
+
+    private String productImageUrl;
+}

--- a/backend_set/src/main/java/org/funding/fund/service/FundService.java
+++ b/backend_set/src/main/java/org/funding/fund/service/FundService.java
@@ -10,13 +10,10 @@ import org.funding.financialProduct.dao.*;
 import org.funding.financialProduct.dto.*;
 import org.funding.financialProduct.vo.*;
 import org.funding.fund.dao.FundDAO;
-import org.funding.fund.dto.FundProductRequestDTO;
+import org.funding.fund.dto.*;
 import org.funding.fund.vo.FundVO;
 import org.funding.fund.vo.enumType.FundType;
 import org.funding.fund.vo.enumType.ProgressType;
-import org.funding.fund.dto.FundListResponseDTO;
-import org.funding.fund.dto.FundDetailResponseDTO;
-import org.funding.fund.dto.FundUpdateRequestDTO;
 import org.funding.fundKeyword.service.FundKeywordService;
 import org.funding.fundKeyword.dto.FundKeywordRequestDTO;
 import org.funding.keyword.vo.KeywordVO;
@@ -692,6 +689,11 @@ public class FundService {
             log.error("Error deleting fund: ", e);
             throw new RuntimeException("펀딩 삭제 중 오류가 발생했습니다.", e);
         }
+    }
+
+    // 유저가 생성한 프로젝트 조회
+    public List<MyFundDetailDTO> findMyCreatedFunds(Long uploaderId) {
+        return fundDAO.findAllByUploaderId(uploaderId);
     }
 
 }

--- a/backend_set/src/main/java/org/funding/project/dao/ProjectDAO.java
+++ b/backend_set/src/main/java/org/funding/project/dao/ProjectDAO.java
@@ -17,10 +17,6 @@ public interface ProjectDAO {
     ChallengeProjectVO selectChallengeByProjectId(Long projectId);
     DonationProjectVO selectDonationByProjectId(Long projectId);
 
-
-//    private final SqlSession sqlSession;
-//    private static final String NAMESPACE = "org.funding.project.mapper.ProjectMapper.";
-
     void insertProject(ProjectVO projectVO);
 
     void insertSavingsProject(SavingsProjectVO savingProjectVO);

--- a/backend_set/src/main/resources/org/funding/fund/dao/FundDAO.xml
+++ b/backend_set/src/main/resources/org/funding/fund/dao/FundDAO.xml
@@ -205,6 +205,30 @@
     </select>
 
 
+    <select id="findAllByUploaderId" resultType="org.funding.fund.dto.MyFundDetailDTO">
+        SELECT
+            f.fund_id AS fundId,
+            f.progress AS progress,
+            f.launch_at AS launchAt,
+            f.end_at AS endAt,
+            f.financial_institution AS financialInstitution,
+            p.name AS productName,
+            p.fund_type AS fundType,
+            (SELECT image_url FROM image
+             WHERE post_id = p.product_id
+               AND image_type = 'Funding'
+             ORDER BY image_id ASC
+                LIMIT 1) AS productImageUrl
+        FROM
+            fund f
+            JOIN
+            financial_product p ON f.product_id = p.product_id
+        WHERE
+            f.upload_user_id = #{uploaderId}
+        ORDER BY
+            f.fund_id DESC
+    </select>
+
 
 
 </mapper>


### PR DESCRIPTION
📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
[x] 기능 추가
[ ] 기능 삭제
[ ] 버그 수정
[ ] 코드 리팩토링
[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
[ ] 코드에 영향을 주지 않는 변경사항 (ex. 오타 수정, 탭 사이즈 변경, 변수명 변경)

📌 이슈 번호
close #185 

✨ 반영 브랜치
feat#185-flow-api-2 -> develop

✨ PR 개요
사용자가 자신이 직접 생성하고 업로드한 펀딩 상품의 목록을 조회할 수 있는 API를 구현했습니다.
이 기능을 통해 펀딩을 생성한 사용자는 마이페이지 등에서 자신의 프로젝트를 관리하고 현황을 쉽게 파악할 수 있습니다.
신규 엔드포인트: GET /api/funds/my-creations

💻 작업 내용
1. 내가 생성한 펀딩 목록 조회 로직 구현
FundController, FundService, FundDAO에 걸쳐 사용자가 생성한 펀딩 목록을 조회하는 로직을 추가했습니다.
Fund 테이블의 upload_user_id를 기준으로 현재 로그인한 사용자의 펀딩만 필터링합니다.

2. MyFundDetailDTO 설계
API 응답 규격을 정의하기 위해, 펀딩의 기본 정보와 관련 상품 정보를 함께 담는 MyFundDetailDTO를 새롭게 설계했습니다.

3. JOIN 및 서브쿼리를 활용한 효율적인 데이터 조회
MyBatis XML 매퍼에 fund와 financial_product 테이블을 JOIN하여 펀딩 정보와 상품명을 한 번에 조회하도록 구현했습니다.
하나의 펀딩에 여러 이미지가 있을 경우를 대비하여, SELECT 절 서브쿼리와 LIMIT 1을 통해 중복 없이 하나의 대표 이미지만 안전하게 가져오도록 최적화했습니다.

🙏 리뷰 요청 사항
쿼리 성능 검토: JOIN과 서브쿼리가 포함된 새로운 조회 쿼리(findAllByUploaderId)에 대해 성능상 이슈가 발생할 여지는 없는지 검토 부탁드립니다.

API 네이밍: 신규 API 엔드포인트인 /api/funds/my-creations가 RESTful 원칙과 저희 팀의 컨벤션에 부합하는지 확인 부탁드립니다. 더 좋은 제안이 있다면 알려주세요!

코드의 일관성: '나의 참여 내역 조회' 등 유사한 다른 기능들과 코드 패턴 및 구조가 일관성을 유지하고 있는지 전반적으로 검토해주시면 감사하겠습니다.