### PR TITLE
refactor: ai 검증 로직 수정 및 수치화

### DIFF
--- a/backend_set/src/main/java/org/funding/challengeLog/vo/ChallengeLogVO.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/vo/ChallengeLogVO.java
@@ -1,6 +1,7 @@
 package org.funding.challengeLog.vo;
 
 import lombok.Data;
+import org.funding.challengeLog.vo.enumType.VerifyType;
 
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -11,7 +12,7 @@ public class ChallengeLogVO {
     private Long logId;
     private Long userChallengeId;
     private Long userId;
-    private boolean verified;
+    private VerifyType verified;
     private String imageUrl;
     private String verifiedResult;
     private LocalDate logDate;

--- a/backend_set/src/main/java/org/funding/challengeLog/vo/enumType/VerifyType.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/vo/enumType/VerifyType.java
@@ -1,0 +1,18 @@
+package org.funding.challengeLog.vo.enumType;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum VerifyType {
+    // ENUM: "검증됨", "검증되지 않음", "휴먼검증필요"
+    Verified, UnVerified, HumanVerify;
+
+    public static VerifyType fromString(String value) {
+        for (VerifyType verifyType : VerifyType.values()) {
+            if (verifyType.name().equals(value)) {
+                return verifyType;
+            }
+        }
+        throw new IllegalArgumentException(value);
+    }
+}

--- a/backend_set/src/main/java/org/funding/openAi/dto/VisionResponseDTO.java
+++ b/backend_set/src/main/java/org/funding/openAi/dto/VisionResponseDTO.java
@@ -1,0 +1,14 @@
+package org.funding.openAi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VisionResponseDTO {
+
+    private int score;
+    private String reason;
+}

--- a/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
+++ b/backend_set/src/main/java/org/funding/security/config/SecurityConfig.java
@@ -144,7 +144,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                             "/api/project/distribution/type",
                             "/api/mail/**",
                             "/api/category/**"
-
                     ).permitAll()
                     .antMatchers("/api/security/all").permitAll()
                     .antMatchers("/api/security/member").hasRole("NORMAL")


### PR DESCRIPTION
## 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
[ ] 기능 추가
[x] 버그 수정
[x] 코드 리팩토링
[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
[ ] 코드에 영향을 주지 않는 변경사항 (ex. 오타 수정, 탭 사이즈 변경, 변수명 변경)

## 📌 이슈 번호
close #201 

✨ 반영 브랜치
refactor#201-api-percent -> develop

✨ PR 개요
기존 AI 챌린지 인증 방식의 정확성과 안정성을 대폭 개선했습니다. 단순 키워드("확인되었습니다") 포함 여부로 검증하던 방식은 AI의 부정적인 답변 문장에 키워드가 포함될 경우, 인증에 실패해야 할 이미지를 성공으로 처리하는 심각한 버그가 있었습니다.

이를 해결하기 위해, OpenAI Vision API가 정형화된 JSON 형식으로 응답하도록 프롬프트를 수정하고, 반환된 적합도 점수(score)를 기반으로 결과를 3단계로 판별하는 새로운 로직을 도입했습니다.

💻 작업 내용
1. 프롬프트 엔지니어링 개선
OpenAI Vision API에 전송하는 프롬프트를 수정하여, 응답을 반드시 {"score": 점수, "reason": "판단 근거"} 형식의 JSON으로 반환하도록 강제했습니다.
이를 통해 AI 답변의 모호성을 제거하고, 기계적으로 파싱하기 용이한 구조를 확보했습니다.

2. AI 응답 처리를 위한 DTO 도입
AI가 반환하는 JSON 응답을 안전하고 명확하게 처리하기 위해 VisionApiResponseDTO를 추가했습니다. Jackson ObjectMapper를 사용하여 JSON 문자열을 해당 DTO 객체로 파싱합니다.

3. 점수 기반 3단계 검증 로직 구현
verifyDailyChallenge 서비스 로직을 대대적으로 리팩토링했습니다.
AI가 반환한 score 값을 기준으로, 검증 결과를 아래 3가지 VerifyType으로 분류합니다.

70점 초과: Verified (검증됨)
20점 이상 70점 이하: HumanVerify (관리자 확인 필요)
20점 미만: UnVerified (검증되지 않음)

4. 데이터 저장 방식 개선 및 오류 처리 로직 변경
challenge_log 테이블에는 이제 단순 성공/실패가 아닌, 위 3가지 VerifyType Enum 상태가 저장됩니다.
verified_result 컬럼에는 AI가 제공한 점수와 판단 근거가 함께 저장되어, 추후 검증 기록을 추적하고 분석하기 용이해졌습니다.
단순히 점수가 낮아 검증에 실패한 경우 RuntimeException을 발생시키는 대신, 해당 상태(UnVerified)를 정상적으로 DB에 기록하도록 오류 처리 로직을 수정했습니다.

🙏 리뷰 요청 사항
프롬프트의 안정성: AI가 항상 지정된 JSON 형식으로만 응답하도록 유도하는 새로운 프롬프트를 검토해주세요. 더 안정적이거나 명확하게 만들 수 있는 개선안이 있다면 의견 부탁드립니다.

점수 임계값(Threshold)의 적절성: 현재 검증 상태를 나누는 기준 점수(70점, 20점)가 합리적으로 설정되었는지 검토 부탁드립니다. 이 값을 향후 쉽게 변경할 수 있도록 설정 파일 등으로 분리하는 것이 좋을지에 대한 의견도 환영합니다.

AI 응답 파싱 예외 처리: analyzeImageWithPrompt 메소드에서 AI가 JSON 형식을 지키지 않았거나, 예상치 못한 응답을 보냈을 경우에 대한 예외 처리 로직이 충분히 안정적인지 확인 부탁드립니다.
