### PR TITLE
Feat#220 에러 응답 통일 기능 구현, 적용

### DIFF
--- a/backend_set/src/main/java/org/funding/S3/controller/S3Controller.java
+++ b/backend_set/src/main/java/org/funding/S3/controller/S3Controller.java
@@ -33,7 +33,7 @@ public class S3Controller {
             imageService.uploadImagesForPost(imageType, postId, files);
             return ResponseEntity.ok("성공적으로 업로드 되었습니다.");
         } catch (IOException e) {
-            return ResponseEntity.status(500).body("업로드가 실패하였습니다: " + e.getMessage());
+            return ResponseEntity.status(404).body("업로드가 실패하였습니다: " + e.getMessage());
         }
     }
 

--- a/backend_set/src/main/java/org/funding/badge/controller/BadgeController.java
+++ b/backend_set/src/main/java/org/funding/badge/controller/BadgeController.java
@@ -28,7 +28,7 @@ public class BadgeController {
     public ResponseEntity<String> createBadge(@RequestBody CreateBadgeDTO createBadgeDTO,
                                               HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
-        badgeService.createBadge(createBadgeDTO);
+        badgeService.createBadge(createBadgeDTO, userId);
         return ResponseEntity.ok("뱃지가 정상적으로 등록되었습니다.");
     }
 
@@ -37,7 +37,8 @@ public class BadgeController {
     @PutMapping("/{id}")
     public ResponseEntity<String> updateBadge(@PathVariable Long id, @RequestBody UpdateBadgeDTO updateBadgeDTO,
                                               HttpServletRequest request) {
-        badgeService.updateBadge(updateBadgeDTO, id);
+        Long userId = (Long) request.getAttribute("userId");
+        badgeService.updateBadge(updateBadgeDTO, id, userId);
         return ResponseEntity.ok("뱃지가 정상적으로 업데이트 되었습니다");
     }
 
@@ -46,7 +47,8 @@ public class BadgeController {
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteBadge(@PathVariable Long id,
                                               HttpServletRequest request) {
-        badgeService.deleteBadge(id);
+        Long userId = (Long) request.getAttribute("userId");
+        badgeService.deleteBadge(id, userId);
         return ResponseEntity.ok("뱃지가 정상적으로 삭제되었습니다.");
     }
 
@@ -71,9 +73,6 @@ public class BadgeController {
     public ResponseEntity<List<BadgeResponseDTO>> getUserBadges(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
 
-        if (userId == null) {
-            return ResponseEntity.status(401).body(null);
-        }
         List<BadgeResponseDTO> userBadges = badgeService.getUserBadges(userId);
 
         return ResponseEntity.ok(userBadges);

--- a/backend_set/src/main/java/org/funding/badge/service/BadgeService.java
+++ b/backend_set/src/main/java/org/funding/badge/service/BadgeService.java
@@ -6,7 +6,13 @@ import org.funding.badge.dto.BadgeResponseDTO;
 import org.funding.badge.dto.CreateBadgeDTO;
 import org.funding.badge.dto.UpdateBadgeDTO;
 import org.funding.badge.vo.BadgeVO;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.BadgeException;
+import org.funding.global.error.exception.MemberException;
 import org.funding.mapping.UserBadgeVO;
+import org.funding.user.dao.MemberDAO;
+import org.funding.user.vo.MemberVO;
+import org.funding.user.vo.enumType.Role;
 import org.funding.votes.dao.VotesDAO;
 import org.springframework.stereotype.Service;
 
@@ -18,9 +24,15 @@ import java.util.List;
 public class BadgeService {
 
     private final BadgeDAO badgeDAO;
+    private final MemberDAO memberDAO;
 
     // 뱃지 생성
-    public void createBadge(CreateBadgeDTO createBadgeDTO) {
+    public void createBadge(CreateBadgeDTO createBadgeDTO, Long userId) {
+        MemberVO member = memberDAO.findById(userId);
+        if (member.getRole() != Role.ROLE_ADMIN) {
+            throw new BadgeException(ErrorCode.ACCESS_DENIED);
+        }
+
         BadgeVO badgeVO = new BadgeVO();
         badgeVO.setName(createBadgeDTO.getName());
         badgeVO.setDescription(createBadgeDTO.getDescription());
@@ -29,7 +41,12 @@ public class BadgeService {
     }
 
     // 뱃지 수정
-    public void updateBadge(UpdateBadgeDTO updateBadgeDTO, Long id) {
+    public void updateBadge(UpdateBadgeDTO updateBadgeDTO, Long id, Long userId) {
+        MemberVO member = memberDAO.findById(userId);
+        if (member.getRole() != Role.ROLE_ADMIN) {
+            throw new BadgeException(ErrorCode.ACCESS_DENIED);
+        }
+
         BadgeVO badgeVO = new BadgeVO();
         badgeVO.setBadgeId(id);
         badgeVO.setName(updateBadgeDTO.getName());
@@ -39,7 +56,12 @@ public class BadgeService {
     }
 
     // 뱃지 삭제
-    public void deleteBadge(Long badgeId) {
+    public void deleteBadge(Long badgeId, Long userId) {
+        MemberVO member = memberDAO.findById(userId);
+        if (member.getRole() != Role.ROLE_ADMIN) {
+            throw new BadgeException(ErrorCode.ACCESS_DENIED);
+        }
+
         badgeDAO.deleteBadge(badgeId);
     }
 
@@ -88,6 +110,11 @@ public class BadgeService {
 
     // 유저가 가진 전체 뱃지 조회
     public List<BadgeResponseDTO> getUserBadges(Long userId) {
+        MemberVO member = memberDAO.findById(userId);
+        if (member.getRole() != Role.ROLE_ADMIN) {
+            throw new BadgeException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
         return badgeDAO.findBadgesByUserId(userId);
     }
 }

--- a/backend_set/src/main/java/org/funding/category/service/CategoryService.java
+++ b/backend_set/src/main/java/org/funding/category/service/CategoryService.java
@@ -7,6 +7,8 @@ import org.funding.category.dto.CategoryRequestDTO;
 import org.funding.category.dto.CategoryWithKeywordsResponseDTO;
 import org.funding.category.vo.CategoryVO;
 import org.funding.exception.DuplicateCategoryException;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.CategoryException;
 import org.funding.keyword.dto.KeywordIdAndNameDTO;
 import org.funding.keyword.service.KeywordService;
 import org.funding.keyword.vo.KeywordVO;
@@ -50,18 +52,16 @@ public class CategoryService {
     public void addCategory(CategoryRequestDTO requestDTO) {
 
         if (categoryDAO.selectCategory(requestDTO.getName()) != null) {
-            throw new DuplicateCategoryException("이미 존재하는 이름의 카테고리입니다.");
+            throw new CategoryException(ErrorCode.SAME_CATEGORY_NAME);
         }
 
         categoryDAO.insertCategory(requestDTO);
     }
 
     public void deleteCategory(String name) {
-
         if (categoryDAO.selectCategory(name) == null) {
-            return;
+            throw new CategoryException(ErrorCode.CATEGORY_NOT_FOUND);
         }
-
         categoryDAO.deleteCategory(name);
     }
 

--- a/backend_set/src/main/java/org/funding/comment/service/CommentService.java
+++ b/backend_set/src/main/java/org/funding/comment/service/CommentService.java
@@ -10,6 +10,8 @@ import org.funding.comment.vo.CommentVO;
 import org.funding.comment.vo.enumType.TargetType;
 import org.funding.fund.dao.FundDAO;
 import org.funding.fund.vo.FundVO;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.CommentException;
 import org.funding.project.dao.ProjectDAO;
 import org.funding.project.vo.ProjectVO;
 import org.springframework.stereotype.Service;
@@ -60,8 +62,7 @@ public class CommentService {
         CommentVO commentById = commentDAO.getCommentById(commentId);
 
         if (commentById == null) {
-            // 삭제할 댓글이 없음.
-            return;
+            throw new CommentException(ErrorCode.NOT_FOUND_COMMENT);
         }
 
         commentDAO.deleteComment(commentId);

--- a/backend_set/src/main/java/org/funding/emailAuth/controller/EmailAuthController.java
+++ b/backend_set/src/main/java/org/funding/emailAuth/controller/EmailAuthController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.funding.emailAuth.dao.EmailDAO;
 import org.funding.emailAuth.vo.EmailAuthVO;
 import org.funding.emailAuth.service.EmailService;
+import org.funding.global.error.ErrorCode;
 import org.funding.security.util.Auth;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,7 +34,7 @@ public class EmailAuthController {
             return ResponseEntity.ok(response);
         } catch (RuntimeException e) {
             Map<String, String> response = Map.of("message", "이메일 전송 실패: " + e.getMessage());
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+            return ResponseEntity.status(ErrorCode.ERROR_EMAIL.getStatus()).body(response);
         }
     }
 

--- a/backend_set/src/main/java/org/funding/fund/controller/FundController.java
+++ b/backend_set/src/main/java/org/funding/fund/controller/FundController.java
@@ -6,6 +6,8 @@ import org.funding.fund.service.FundService;
 import org.funding.fund.vo.FundVO;
 import org.funding.fund.vo.enumType.FundType;
 import org.funding.fund.vo.enumType.ProgressType;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.FundException;
 import org.funding.security.util.Auth;
 import org.funding.user.vo.MemberVO;
 import org.springframework.http.MediaType;
@@ -35,7 +37,7 @@ public class FundController {
             HttpServletRequest servletRequest) {
         Long userId = (Long) servletRequest.getAttribute("userId");
         fundService.createSavingsFund(request, images, userId);
-        return ResponseEntity.ok("Savings fund successfully created.");
+        return ResponseEntity.ok("펀딩이 성공적으로 생성되었습니다.");
     }
 
     @Auth
@@ -46,7 +48,7 @@ public class FundController {
             HttpServletRequest servletRequest) {
         Long userId = (Long) servletRequest.getAttribute("userId");
         fundService.createLoanFund(request, images, userId);
-        return ResponseEntity.ok("Loan fund successfully created.");
+        return ResponseEntity.ok("펀딩이 성공적으로 생성되었습니다.");
     }
 
     @Auth
@@ -57,7 +59,7 @@ public class FundController {
             HttpServletRequest servletRequest) {
         Long userId = (Long) servletRequest.getAttribute("userId");
         fundService.createChallengeFund(request, images, userId);
-        return ResponseEntity.ok("Challenge fund successfully created.");
+        return ResponseEntity.ok("펀딩이 성공적으로 생성되었습니다.");
     }
 
     @Auth
@@ -68,7 +70,7 @@ public class FundController {
             HttpServletRequest servletRequest) {
         Long userId = (Long) servletRequest.getAttribute("userId");
         fundService.createDonationFund(request, images, userId);
-        return ResponseEntity.ok("Donation fund successfully created.");
+        return ResponseEntity.ok("펀딩이 성공적으로 생성되었습니다.");
     }
 
     //summary = "백엔드 개발용 펀딩 상품 입력 템플릿(프론트 연결X, 프로젝트 연결 후 삭제 예정API)",
@@ -222,7 +224,7 @@ public class FundController {
     public ResponseEntity<?> getMyAllCreatedFunds(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         if (userId == null) {
-            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+            throw new FundException(ErrorCode.MEMBER_NOT_FOUND);
         }
         List<MyFundDetailDTO> myFunds = fundService.findMyCreatedFunds(userId);
 

--- a/backend_set/src/main/java/org/funding/global/error/ErrorCode.java
+++ b/backend_set/src/main/java/org/funding/global/error/ErrorCode.java
@@ -1,0 +1,67 @@
+package org.funding.global.error;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT_VALUE(400, "COMMON001", "입력값이 올바르지 않습니다."),
+    METHOD_NOT_ALLOWED(405, "COMMON002", "지원하지 않는 HTTP 메소드입니다."),
+    INTERNAL_SERVER_ERROR(500, "COMMON003", "서버 내부 오류가 발생했습니다."),
+
+    // 멤버 에러
+    MEMBER_NOT_FOUND(404, "MEMBER001", "해당 사용자를 찾을 수 없습니다."),
+    EMAIL_DUPLICATION(400, "MEMBER002", "이미 사용 중인 이메일입니다."),
+    LOGIN_INPUT_INVALID(400, "MEMBER003", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    MEMBER_NOT_ADMIN(401, "MEMBER004", "해당 멤버는 관리자가 아닙니다."),
+
+    // 펀딩 에러
+    FUNDING_NOT_FOUND(404, "FUNDING001", "해당 펀딩을 찾을 수 없습니다."),
+    FAIL_FUNDING(400, "FUNDING002", "펀딩 생성에 실패하였습니다."),
+    FAIL_FUND_UPDATE(402, "FUNDING003", "펀딩 수정에 실패하였습니다."),
+    FAIL_DELETE_FUND(405, "FUNDING004", "펀딩 삭제중 에러가 발생하였습니다."),
+    NOT_FUND_TYPE(406, "FUNDING005", "지원하지 않는 타입 정보입니다."),
+    FAIL_ENTER_FUND(404, "FUNDING006", "펀딩 가입 처리중 오류 발생"),
+
+    // 프로젝트 에러
+    PROJECT_NOT_FOUND(404, "PROJECT001", "해당 프로젝트를 찾을 수 없습니다."),
+    FAIL_PROJECT(400, "PROJECT002", "프로젝트 생성에 실패하였습니다."),
+    NOT_FOUND_PROJECT_TYPE(402, "PROJECT003", "찾을 수 없는 프로젝트 타입니다."),
+    NOT_PROJECT_TYPE(406, "PROJECT004", "지원하지 않는 타입 정보입니다."),
+    NOT_PROJECT_OWNER(404, "PROJECT005", "프로젝트의 작성자가 아닙니다"),
+
+    // 인증 에러
+    AUTHENTICATION_FAILED(401, "A001", "인증에 실패하였습니다."),
+    ACCESS_DENIED(403, "A002", "해당 권한이 없습니다."),
+
+    // 카테고리 에러
+    SAME_CATEGORY_NAME(404, "CATEGORY001", "이미 존재하는 이름의 카테고리입니다."),
+    CATEGORY_NOT_FOUND(404, "CATEGORY002", "존재하지 않는 카테고리 이름입니다."),
+
+    // 댓글 에러
+    NOT_FOUND_COMMENT(404, "COMMENT001", "삭제할 댓글이 없습니다."),
+
+    // 이메일 전송 에러
+    ERROR_EMAIL(400, "EMAIL001", "이메일 전송 과정에서 에러가 발생했습니다."),
+
+    // openai 에러
+    FAIL_VISION_AI(400, "AI001", "이미지 검증에 실패하였습니다."),
+
+    // 결제 애러
+    FAIL_PAYMENT(400, "PAYMENT001", "결제 정보 생성에 실패하였습니다."),
+    ENTER_DONATE_AMOUNT(401, "PAYMENT002", "기부 금액을 입력해주세요"),
+    NOT_FOUND_PAYMENT(404, "PAYMENT003", "결제 정보를 찾을 수 없습니다."),
+    FAIL_VERIFY_PAYMENT(405, "PAYMENT004", "결제 검증에 실패하였습니다."),
+    FAIL_SUCCESS_PAY(406, "PAYMENT005", "결제 완료 처리 실패"),
+    NO_HAVE_PAYMENT(400, "PAYMENT006", "결제가 필요한 펀딩이 아닙니다"),
+    NOT_FOUND_PORT_ONE_TOKEN(404, "PAYMENT007", "포트원 토큰 획득 실패");
+
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/backend_set/src/main/java/org/funding/global/error/ErrorCode.java
+++ b/backend_set/src/main/java/org/funding/global/error/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     FAIL_DELETE_FUND(405, "FUNDING004", "펀딩 삭제중 에러가 발생하였습니다."),
     NOT_FUND_TYPE(406, "FUNDING005", "지원하지 않는 타입 정보입니다."),
     FAIL_ENTER_FUND(404, "FUNDING006", "펀딩 가입 처리중 오류 발생"),
+    END_FUND(404, "FUNDING007", "해당 펀딩은 종료되었습니다."),
 
     // 프로젝트 에러
     PROJECT_NOT_FOUND(404, "PROJECT001", "해당 프로젝트를 찾을 수 없습니다."),
@@ -58,7 +59,41 @@ public enum ErrorCode {
     FAIL_VERIFY_PAYMENT(405, "PAYMENT004", "결제 검증에 실패하였습니다."),
     FAIL_SUCCESS_PAY(406, "PAYMENT005", "결제 완료 처리 실패"),
     NO_HAVE_PAYMENT(400, "PAYMENT006", "결제가 필요한 펀딩이 아닙니다"),
-    NOT_FOUND_PORT_ONE_TOKEN(404, "PAYMENT007", "포트원 토큰 획득 실패");
+    NOT_FOUND_PORT_ONE_TOKEN(404, "PAYMENT007", "포트원 토큰 획득 실패"),
+
+    // 투표 에러
+    ALREADY_RETRY_VOTE(400, "RETRY VOTE001", "이미 투표하신 펀딩입니다."),
+    NOT_END_FUND(401, "RETRY VOTE002", "아직 펀딩이 종료되지 않았습니다."),
+    NOT_CANCEL_RETRY_VOTE(400, "RETRY VOTE003",  "투표 미 참여시 투표를 취소할 수 없습니다."),
+
+    // 첼린지 에러
+    NOT_FOUND_CHALLENGE(404, "CHALLENGE001", "해당 챌린지를 찾을 수 없습니다."),
+    ALREADY_JOIN_CHALLENGE(400, "CHALLENGE002", "이미 챌린지에 가입한 회원입니다."),
+    MISS_DATE_CHALLENGE(401, "CHALLENGE003", "챌린지에 참여 가능한 날짜가 아닙니다."),
+    ALREADY_VERIFIED(401, "CHALLENGE004", "이미 인증된 날짜입니다."),
+    NOT_CHALLENGE_MEMBER(402, "CHALLENGE005", "챌린지에 가입되지 않은 회원입니다."),
+    NO_CHALLENGE(403, "CHALLENGE006", "해당 상품은 챌린지 상품이 아닙니다."),
+
+    // 상품 에러
+    NOT_FOUND_PRODUCT(404, "PRODUCT001", "해당 상품을 찾을 수 없습니다."),
+
+    // 기부 에러
+    OVER_DONATE_AMOUNT(400, "DONATE001", "기부 금액에서 벗어난 금액입니다."),
+    NOT_FOUND_DONATE(401,"DONATE002", "기부 내역을 찾을 수 없습니다."),
+    CAN_NOT_DELETE(404, "DONATE003", "기부 내역 삭제 권한이 없습니다."),
+    DONE_DONATE(400, "DONATE004", "해당 기부는 종료되었습니다."),
+
+    // 대출 에러
+    AMOUNT_OVER(400, "LOAN001", "대출 한도가 넘었습니다."),
+    NOT_FOUND_LOAN(401, "LOAN002", "신청 내역이 존재하지 않습니다."),
+    ALREADY_LOAN(401, "LOAN003", "이미 지급 완료된 대출이라 취소가 불가합니다."),
+    ALREADY_ACCEPT(400, "LOAN004", "이미 처리된 신청입니다."),
+    NOT_PAYMENT(401, "LOAN004", "지급은 승인 후에 가능합니다."),
+
+    // 저축 에러
+    NOT_FOUND_SAVING(400, "SAVING001", "해당 저축에 신청되어있지 않습니다."),
+    NO_CANCEL_SAVING(401, "SAVING002", "저축 해지 권한이 없습니다.")
+    ;
 
 
     private final int status;

--- a/backend_set/src/main/java/org/funding/global/error/ErrorResponse.java
+++ b/backend_set/src/main/java/org/funding/global/error/ErrorResponse.java
@@ -1,0 +1,20 @@
+package org.funding.global.error;
+
+import lombok.Getter;
+@Getter
+public class ErrorResponse {
+
+    private final int status;       // HTTP 상태 코드
+    private final String code;         // 커스텀 에러 코드
+    private final String message;      // 에러 메시지
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.status = errorCode.getStatus();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/GlobalExceptionHandler.java
+++ b/backend_set/src/main/java/org/funding/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package org.funding.global.error;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.funding.global.error.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice // 모든 @RestController에서 발생하는 예외를 처리
+public class GlobalExceptionHandler {
+
+    /**
+     * @Valid를 이용한 유효성 검사에서 실패(예: @NotBlank)했을 때 처리하는 핸들러
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 우리가 직접 정의한 비즈니스 로직상 예외를 처리하는 핸들러
+     */
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+        log.error("handleBusinessException", e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    /**
+     * 위에서 처리하지 못한 모든 예외를 처리하는 핸들러
+     */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/BadgeException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/BadgeException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class BadgeException extends BusinessException {
+    public BadgeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/BusinessException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package org.funding.global.error.exception;
+
+import lombok.Getter;
+import org.funding.global.error.ErrorCode;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/CategoryException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/CategoryException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class CategoryException extends BusinessException {
+    public CategoryException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/CommentException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/CommentException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class CommentException extends BusinessException {
+    public CommentException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/EntityNotFoundException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/EntityNotFoundException.java
@@ -1,0 +1,10 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class EntityNotFoundException extends BusinessException {
+
+    public EntityNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/FundException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/FundException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class FundException extends BusinessException{
+    public FundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/KeywordException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/KeywordException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class KeywordException extends BusinessException {
+    public KeywordException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/MemberException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/MemberException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class MemberException extends BusinessException {
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/OpenAiException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/OpenAiException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class OpenAiException extends BusinessException {
+    public OpenAiException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/PaymentException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/PaymentException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class PaymentException extends BusinessException{
+    public PaymentException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/ProjectException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/ProjectException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class ProjectException extends BusinessException {
+    public ProjectException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/RetryVotesException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/RetryVotesException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class RetryVotesException extends BusinessException {
+    public RetryVotesException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/UserChallengeException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/UserChallengeException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class UserChallengeException extends BusinessException{
+    public UserChallengeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/UserDonationException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/UserDonationException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class UserDonationException extends BusinessException {
+    public UserDonationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/UserLoanException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/UserLoanException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class UserLoanException extends BusinessException {
+    public UserLoanException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/global/error/exception/UserSavingException.java
+++ b/backend_set/src/main/java/org/funding/global/error/exception/UserSavingException.java
@@ -1,0 +1,9 @@
+package org.funding.global.error.exception;
+
+import org.funding.global.error.ErrorCode;
+
+public class UserSavingException extends BusinessException{
+    public UserSavingException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend_set/src/main/java/org/funding/keyword/service/KeywordService.java
+++ b/backend_set/src/main/java/org/funding/keyword/service/KeywordService.java
@@ -1,6 +1,8 @@
 package org.funding.keyword.service;
 
 import lombok.RequiredArgsConstructor;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.KeywordException;
 import org.funding.keyword.dao.KeywordDAO;
 import org.funding.keyword.dto.KeywordRequestDTO;
 import org.funding.keyword.vo.KeywordVO;
@@ -37,10 +39,10 @@ public class KeywordService {
     public void addKeyword(KeywordRequestDTO requestDTO, Long userId) {
         MemberVO member = memberDAO.findById(userId);
         if (member == null) {
-            throw new RuntimeException("해당 멤버는 존재하지 않습니다.");
+            throw new KeywordException(ErrorCode.MEMBER_NOT_FOUND);
         }
         if (member.getRole() != Role.ROLE_ADMIN) {
-            throw new RuntimeException("해당 멤버는 관리자가 아닙니다.");
+            throw new KeywordException(ErrorCode.MEMBER_NOT_ADMIN);
         }
         keywordDAO.insertKeyword(requestDTO);
     }
@@ -48,10 +50,10 @@ public class KeywordService {
     public void deleteKeyword(String name, Long userId) {
         MemberVO member = memberDAO.findById(userId);
         if (member == null) {
-            throw new RuntimeException("해당 멤버는 존재하지 않습니다.");
+            throw new KeywordException(ErrorCode.MEMBER_NOT_FOUND);
         }
         if (member.getRole() != Role.ROLE_ADMIN) {
-            throw new RuntimeException("해당 멤버는 관리자가 아닙니다.");
+            throw new KeywordException(ErrorCode.MEMBER_NOT_ADMIN);
         }
         keywordDAO.deleteKeyword(name);
     }

--- a/backend_set/src/main/java/org/funding/openAi/client/OpenAIVisionClient.java
+++ b/backend_set/src/main/java/org/funding/openAi/client/OpenAIVisionClient.java
@@ -3,6 +3,8 @@ package org.funding.openAi.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.OpenAiException;
 import org.funding.openAi.dto.VisionResponseDTO;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -84,7 +86,7 @@ public class OpenAIVisionClient {
             return mapper.readValue(content, VisionResponseDTO.class);
         } catch (Exception e) {
             log.error("GPT-4 Vision API 요청 중 예외 발생", e);
-            throw new RuntimeException("이미지 검증 처리중 에러 발생");
+            throw new OpenAiException(ErrorCode.FAIL_VISION_AI);
         }
     }
 }

--- a/backend_set/src/main/java/org/funding/openAi/service/FundAIService.java
+++ b/backend_set/src/main/java/org/funding/openAi/service/FundAIService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.funding.fund.vo.FundVO;
 import org.funding.fund.vo.enumType.FundType;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.OpenAiException;
 import org.funding.openAi.client.OpenAIClient;
 import org.funding.openAi.dao.FundAIDAO;
 import org.json.JSONArray;
@@ -32,12 +34,12 @@ public class FundAIService {
     public List<FundVO> getSimilarFunds(Long fundId) {
         FundVO fund = fundAIDAO.findFundById(fundId);
         if (fund == null) {
-            throw new RuntimeException("해당 펀딩이 존재하지 않습니다");
+            throw new OpenAiException(ErrorCode.FUNDING_NOT_FOUND);
         }
 
         FundType fundType = fundAIDAO.findFundTypeByProductId(fund.getProductId());
         if (fundType == null) {
-            throw new RuntimeException("펀딩 상품의 타입 정보가 없습니다.");
+            throw new OpenAiException(ErrorCode.NOT_FUND_TYPE);
         }
 
         return fundAIDAO.findFundsByFundTypeExcludeSelf(fundType.toString(), fundId);
@@ -48,7 +50,7 @@ public class FundAIService {
         FundVO targetFund = findFundById(fundId);
 
         if (targetFund == null) {
-            throw new RuntimeException("해당 펀딩이 존재하지 않습니다.");
+            throw new OpenAiException(ErrorCode.FUNDING_NOT_FOUND);
         }
 
         List<FundVO> candidates = getSimilarFunds(fundId);

--- a/backend_set/src/main/java/org/funding/project/service/ProjectService.java
+++ b/backend_set/src/main/java/org/funding/project/service/ProjectService.java
@@ -6,6 +6,8 @@ import org.funding.S3.service.S3ImageService;
 import org.funding.S3.vo.S3ImageVO;
 import org.funding.S3.vo.enumType.ImageType;
 import org.funding.fund.dto.FundListResponseDTO;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.ProjectException;
 import org.funding.keyword.vo.KeywordVO;
 import org.funding.project.dao.ProjectDAO;
 import org.funding.project.dto.response.ProjectListDTO;
@@ -68,7 +70,7 @@ public class ProjectService {
     public ProjectVO selectProjectById(Long projectId) {
         ProjectVO project = projectDAO.selectProjectById(projectId);
         if (project == null) {
-            throw new RuntimeException("해당 ID의 프로젝트가 존재하지 않습니다.");
+            throw new ProjectException(ErrorCode.PROJECT_NOT_FOUND);
         }
         return project;
     }
@@ -98,7 +100,7 @@ public class ProjectService {
                 break;
 
             default:
-                throw new RuntimeException("알 수 없는 프로젝트 타입입니다: " + project.getProjectType());
+                throw new ProjectException(ErrorCode.NOT_FOUND_PROJECT_TYPE);
         }
 
 
@@ -303,7 +305,7 @@ public class ProjectService {
                 break;
 
             default:
-                throw new IllegalArgumentException("지원하지 않는 프로젝트 타입입니다: " + createRequestDTO.getProjectType());
+                throw new ProjectException(ErrorCode.NOT_PROJECT_TYPE);
         }
 
         List<ProjectKeywordRequestDTO> projectKeywordRequestList =
@@ -327,7 +329,7 @@ public class ProjectService {
     public void deleteProject(Long projectId, Long userId) {
         ProjectVO projectVO = projectDAO.selectProjectById(projectId);
         if (!Objects.equals(projectVO.getUserId(), userId)) {
-            throw new RuntimeException("해당 프로젝트의 작성자가 아닙니다.");
+            throw new ProjectException(ErrorCode.NOT_PROJECT_OWNER);
         }
         switch (projectVO.getProjectType()) {
             case Savings:
@@ -347,7 +349,7 @@ public class ProjectService {
                 break;
 
             default:
-                throw new IllegalArgumentException("지원하지 않는 프로젝트 타입입니다: " + projectVO.getProjectType());
+                throw new ProjectException(ErrorCode.NOT_PROJECT_TYPE);
         }
 
         projectDAO.deleteProjectById(projectId);

--- a/backend_set/src/main/java/org/funding/retryVotes/controller/RetryVotesController.java
+++ b/backend_set/src/main/java/org/funding/retryVotes/controller/RetryVotesController.java
@@ -2,6 +2,8 @@ package org.funding.retryVotes.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.funding.fund.vo.FundVO;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.RetryVotesException;
 import org.funding.retryVotes.dto.DoVoteRequestDTO;
 import org.funding.retryVotes.dto.MyVotedFundDTO;
 import org.funding.retryVotes.service.RetryVotesService;
@@ -45,7 +47,7 @@ public class RetryVotesController {
         Long userId = (Long) request.getAttribute("userId");
 
         if (userId == null) {
-            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+            throw new RetryVotesException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
         List<MyVotedFundDTO> myVotedFunds = retryVotesService.findMyVotedFunds(userId);

--- a/backend_set/src/main/java/org/funding/retryVotes/service/RetryVotesService.java
+++ b/backend_set/src/main/java/org/funding/retryVotes/service/RetryVotesService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.funding.fund.dao.FundDAO;
 import org.funding.fund.vo.FundVO;
 import org.funding.fund.vo.enumType.ProgressType;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.RetryVotesException;
 import org.funding.retryVotes.dao.RetryVotesDAO;
 import org.funding.retryVotes.dto.DoVoteRequestDTO;
 import org.funding.retryVotes.dto.MyVotedFundDTO;
@@ -24,14 +26,14 @@ public class RetryVotesService {
         boolean alreadyVoted = retryVotesDAO.existsVoteByUserIdAndFundingId(userId, voteRequestDTO.getFundId());
         // 중복 검사
         if (alreadyVoted) {
-            throw new IllegalStateException("이미 투표하신 펀딩입니다.");
+            throw new RetryVotesException(ErrorCode.ALREADY_RETRY_VOTE);
         }
 
         FundVO fund = fundDAO.selectById(voteRequestDTO.getFundId());
 
         // 펀딩이 종료됐는지 검사
         if (fund.getProgress() != ProgressType.End) {
-            throw new IllegalStateException("아직 펀딩이 종료되지 않았습니다.");
+            throw new RetryVotesException(ErrorCode.NOT_END_FUND);
         }
 
         RetryVotesVO retryVotesVO = new RetryVotesVO();
@@ -53,14 +55,14 @@ public class RetryVotesService {
         boolean alreadyVoted = retryVotesDAO.existsVoteByUserIdAndFundingId(userId, voteRequestDTO.getFundId());
         // 투표 취소방지
         if (!alreadyVoted) {
-            throw new IllegalStateException("투표를 안하셨기에 투표를 취소 할 수 없습니다.");
+            throw new RetryVotesException(ErrorCode.NOT_CANCEL_RETRY_VOTE);
         }
 
         FundVO fund = fundDAO.selectById(voteRequestDTO.getFundId());
 
         // 펀딩이 종료됐는지 검사
         if (fund.getProgress() != ProgressType.End) {
-            throw new IllegalStateException("아직 펀딩이 종료되지 않았습니다.");
+            throw new RetryVotesException(ErrorCode.NOT_END_FUND);
         }
         retryVotesDAO.deleteRetryVotes(voteRequestDTO);
 

--- a/backend_set/src/main/java/org/funding/user/controller/MyPageController.java
+++ b/backend_set/src/main/java/org/funding/user/controller/MyPageController.java
@@ -77,10 +77,13 @@ public class MyPageController {
         @ApiResponse(code = 401, message = "인증 실패"),
         @ApiResponse(code = 400, message = "잘못된 요청")
     })
+    @Auth
     @PutMapping("/keywords")
-    public ResponseEntity<?> updateMyKeywords(@RequestBody List<String> keywords) {
+    public ResponseEntity<?> updateMyKeywords(@RequestBody List<String> keywords,
+                                              HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
         try {
-            myPageService.updateMyKeywords(keywords);
+            myPageService.updateMyKeywords(keywords, userId);
             return ResponseEntity.ok("키워드가 성공적으로 수정되었습니다.");
         } catch (IllegalStateException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
@@ -97,10 +100,13 @@ public class MyPageController {
         @ApiResponse(code = 401, message = "인증 실패"),
         @ApiResponse(code = 400, message = "잘못된 요청")
     })
+    @Auth
     @PutMapping("/account")
-    public ResponseEntity<?> updateAccountInfo(@RequestBody UpdateAccountRequestDTO request) {
+    public ResponseEntity<?> updateAccountInfo(@RequestBody UpdateAccountRequestDTO request,
+                                               HttpServletRequest servletRequest) {
+        Long userId = (Long) servletRequest.getAttribute("userId");
         try {
-            myPageService.updateAccountInfo(request);
+            myPageService.updateAccountInfo(request, userId);
             return ResponseEntity.ok("개인정보가 성공적으로 수정되었습니다.");
         } catch (IllegalStateException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
@@ -140,10 +146,12 @@ public class MyPageController {
         @ApiResponse(code = 200, message = "조회 성공"),
         @ApiResponse(code = 401, message = "인증 실패")
     })
+    @Auth
     @GetMapping("/projects")
-    public ResponseEntity<?> getMyProjects() {
+    public ResponseEntity<?> getMyProjects(HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
         try {
-            List<ProjectListDTO> projects = myPageService.getMyProjects();
+            List<ProjectListDTO> projects = myPageService.getMyProjects(userId);
             return ResponseEntity.ok(projects);
         } catch (IllegalStateException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/backend_set/src/main/java/org/funding/user/service/MemberService.java
+++ b/backend_set/src/main/java/org/funding/user/service/MemberService.java
@@ -2,6 +2,8 @@ package org.funding.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.funding.badge.service.BadgeService;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.MemberException;
 import org.funding.security.util.JwtProcessor;
 import org.funding.user.dao.MemberDAO;
 import org.funding.user.dto.MemberSignupDTO;
@@ -55,7 +57,7 @@ public class MemberService {
     public MemberLoginResponseDTO login(String email, String password) {
         MemberVO member = memberDAO.findByEmail(email);
         if (member == null || !passwordEncoder.matches(password, member.getPassword())) {
-            throw new RuntimeException("비밀번호가 일치하지 않습니다, 회원이 없습니다");
+            throw new MemberException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
         // 뱃지 검증

--- a/backend_set/src/main/java/org/funding/user/service/MyPageService.java
+++ b/backend_set/src/main/java/org/funding/user/service/MyPageService.java
@@ -34,40 +34,6 @@ public class MyPageService {
     private final UserKeywordDAO userKeywordDAO;
     private final VotesService votesService;
 
-    // 현재 로그인한 사용자의 ID를 가져옴
-    public Long getCurrentUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        
-        // 임시 테스트용: 인증이 없어도 테스트 사용자 ID 반환
-        if (authentication == null || authentication.getName() == null || "anonymousUser".equals(authentication.getName())) {
-            System.out.println("DEBUG: No authentication found, using test user ID: 1");
-//            return 1L; // 테스트용 사용자 ID // 추후 삭제
-            return null;
-        }
-
-        
-        String username = authentication.getName();
-        System.out.println("DEBUG: Authentication username = " + username);
-        
-        // username으로 먼저 시도
-        MemberVO member = memberDAO.findByUsername(username);
-        
-        // username으로 찾지 못하면 email로 시도 // 추후 삭제
-        if (member == null) {
-            member = memberDAO.findByEmail(username);
-            System.out.println("DEBUG: Trying email lookup, found member = " + (member != null ? member.getUsername() : "null"));
-        } else {
-            System.out.println("DEBUG: Found member by username = " + member.getUsername());
-        }
-        
-        if (member == null) {
-            System.out.println("DEBUG: Member not found, using test user ID: 1");
-            return 1L; // 테스트용 사용자 ID
-        }
-        
-        return member.getUserId();
-    }
-
     // 4.1 마이페이지 조회
     public MyPageResponseDTO getMyPageInfo(Long userId) {
 
@@ -111,8 +77,7 @@ public class MyPageService {
 
     // 4.2.3 키워드 수정
     @Transactional
-    public void updateMyKeywords(List<String> newKeywords) {
-        Long userId = getCurrentUserId();
+    public void updateMyKeywords(List<String> newKeywords, Long userId) {
         
         // 기존 키워드 삭제
         userKeywordDAO.deleteKeywordsByUserId(userId);
@@ -128,8 +93,7 @@ public class MyPageService {
 
     // 4.3 개인정보 수정
     @Transactional
-    public void updateAccountInfo(UpdateAccountRequestDTO request) {
-        Long userId = getCurrentUserId();
+    public void updateAccountInfo(UpdateAccountRequestDTO request, Long userId) {
         MemberVO member = memberDAO.findById(userId);
         
         member.setUsername(request.getUsername());
@@ -157,8 +121,7 @@ public class MyPageService {
     }
 
     // 4.5.1 작성한 프로젝트 조회 - ProjectListDTO 사용
-    public List<ProjectListDTO> getMyProjects() {
-        Long userId = getCurrentUserId();
+    public List<ProjectListDTO> getMyProjects(Long userId) {
         List<ProjectVO> projects = projectDAO.findByUserId(userId);
         
         return projects.stream()

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/UserChallengeController.java
@@ -2,6 +2,8 @@ package org.funding.userChallenge.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.funding.S3.service.S3ImageService;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.UserChallengeException;
 import org.funding.security.util.Auth;
 import org.funding.userChallenge.dto.*;
 import org.funding.userChallenge.service.UserChallengeService;
@@ -65,7 +67,7 @@ public class UserChallengeController {
         Long userId = (Long) request.getAttribute("userId");
         // userId가 없는 경우 예외 처리 (필요 시)
         if (userId == null) {
-            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+            throw new UserChallengeException(ErrorCode.MEMBER_NOT_FOUND);
         }
         List<UserChallengeDetailDTO> myChallenges = userChallengeService.findMyChallenges(userId);
         return ResponseEntity.ok(myChallenges);
@@ -79,7 +81,7 @@ public class UserChallengeController {
         ChallengeDetailResponseDTO responseDTO = userChallengeService.getChallengeDetails(userChallengeId);
 
         if (responseDTO == null) {
-            return ResponseEntity.status(404).body("해당 챌린지를 찾을 수 없습니다.");
+            throw new UserChallengeException(ErrorCode.NOT_FOUND_CHALLENGE);
         }
         return ResponseEntity.ok(responseDTO);
     }

--- a/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
+++ b/backend_set/src/main/java/org/funding/userDonation/controller/UserDonationController.java
@@ -1,6 +1,8 @@
 package org.funding.userDonation.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.UserDonationException;
 import org.funding.security.util.Auth;
 import org.funding.userDonation.dto.DonateRequestDTO;
 import org.funding.userDonation.dto.DonateResponseDTO;
@@ -70,7 +72,7 @@ public class UserDonationController {
     public ResponseEntity<?> getMyAllDonations(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         if (userId == null) {
-            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+            throw new UserDonationException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
         List<UserDonationDetailDTO> myDonations = userDonationService.findMyDonations(userId);

--- a/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
+++ b/backend_set/src/main/java/org/funding/userLoan/controller/UserLoanController.java
@@ -1,6 +1,8 @@
 package org.funding.userLoan.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.UserLoanException;
 import org.funding.security.util.Auth;
 import org.funding.userLoan.dto.*;
 import org.funding.userLoan.service.UserLoanService;
@@ -70,7 +72,7 @@ public class UserLoanController {
     public ResponseEntity<?> getMyAllLoans(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         if (userId == null) {
-            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+            throw new UserLoanException(ErrorCode.MEMBER_NOT_FOUND);
         }
         List<UserLoanDetailDTO> myLoans = userLoanService.getAllUserLoans(userId);
         return ResponseEntity.ok(myLoans);

--- a/backend_set/src/main/java/org/funding/userSaving/controller/UserSavingController.java
+++ b/backend_set/src/main/java/org/funding/userSaving/controller/UserSavingController.java
@@ -1,6 +1,8 @@
 package org.funding.userSaving.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.UserSavingException;
 import org.funding.security.util.Auth;
 import org.funding.userSaving.dto.UserSavingDetailDTO;
 import org.funding.userSaving.dto.UserSavingRequestDTO;
@@ -59,7 +61,7 @@ public class UserSavingController {
     public ResponseEntity<?> getMyAllSavings(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         if (userId == null) {
-            return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
+            throw new UserSavingException(ErrorCode.MEMBER_NOT_FOUND);
         }
         List<UserSavingDetailDTO> mySavings = userSavingService.findMySavings(userId);
         return ResponseEntity.ok(mySavings);

--- a/backend_set/src/main/java/org/funding/userSaving/service/UserSavingService.java
+++ b/backend_set/src/main/java/org/funding/userSaving/service/UserSavingService.java
@@ -5,12 +5,15 @@ import org.funding.S3.dao.S3ImageDAO;
 import org.funding.S3.vo.S3ImageVO;
 import org.funding.S3.vo.enumType.ImageType;
 import org.funding.badge.service.BadgeService;
+import org.funding.global.error.ErrorCode;
+import org.funding.global.error.exception.UserSavingException;
 import org.funding.user.dao.MemberDAO;
 import org.funding.user.vo.MemberVO;
 import org.funding.userSaving.dao.UserSavingDAO;
 import org.funding.userSaving.dto.UserSavingDetailDTO;
 import org.funding.userSaving.dto.UserSavingRequestDTO;
 import org.funding.userSaving.vo.UserSavingVO;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
@@ -32,7 +35,7 @@ public class UserSavingService {
     public String applySaving(UserSavingRequestDTO userSavingRequestDTO, Long userId) {
         MemberVO member = memberDAO.findById(userId);
         if (member == null) {
-            throw new RuntimeException("해당 멤버는 존재하지 않습니다.");
+            throw new UserSavingException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
         UserSavingVO userSaving = new UserSavingVO();
@@ -52,10 +55,10 @@ public class UserSavingService {
     public String cancelSaving(Long userSavingId, Long userId) {
         UserSavingVO userSaving = userSavingDAO.findById(userSavingId);
         if (userSaving == null) {
-            throw new RuntimeException("해당 저축에 신청되어있지 않습니다.");
+            throw new UserSavingException(ErrorCode.NOT_FOUND_SAVING);
         }
         if (!Objects.equals(userSaving.getUserId(), userId)) {
-            throw new RuntimeException("해지 권한이 없습니다. (본인만 가능)");
+            throw new UserSavingException(ErrorCode.NO_CANCEL_SAVING);
         }
 
         userSavingDAO.deleteUserSaving(userSavingId);
@@ -66,7 +69,7 @@ public class UserSavingService {
     public UserSavingVO findById(Long userSavingId) {
         UserSavingVO userSaving = userSavingDAO.findById(userSavingId);
         if (userSaving == null) {
-            throw new RuntimeException("해당 저축 상품이 존재하지 않습니다.");
+            throw new UserSavingException(ErrorCode.NOT_FOUND_SAVING);
         }
         return userSaving;
     }


### PR DESCRIPTION
## 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
[x] 기능 추가
[ ] 기능 삭제
[x] 버그 수정
[x] 코드 리팩토링
[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
[ ] 코드에 영향을 주지 않는 변경사항 (ex. 오타 수정, 탭 사이즈 변경, 변수명 변경)

## 📌 이슈 번호
close #220 

✨ 반영 브랜치
feat#220-error-response -> develop

✨ PR 개요
기존에 모든 비즈니스 로직의 예외를 RuntimeException으로 처리하여, 클라이언트에게 항상 500 Internal Server Error로 응답하던 문제를 해결했습니다.
@RestControllerAdvice를 이용한 전역 예외 처리(Global Exception Handling) 메커니즘을 도입하여, 이제 각 상황에 맞는 명확한 HTTP 상태 코드(예: 400, 404)와 일관된 형식의 에러 메시지를 응답합니다. 이를 통해 클라이언트와의 통신 안정성을 높이고 디버깅 효율을 개선했습니다.

💻 작업 내용
1. 전역 예외 핸들러(GlobalExceptionHandler) 도입
@RestControllerAdvice를 사용하여 모든 컨트롤러에서 발생하는 예외를 한 곳에서 중앙 관리하도록 구조를 변경했습니다.
@ExceptionHandler를 사용하여 특정 예외 타입별로(예: BusinessException, MethodArgumentNotValidException) 적절한 HTTP 응답을 생성하도록 구현했습니다.
처리되지 않은 나머지 예외들은 500 Internal Server Error로 응답하여, 서버 내부의 스택 트레이스(stack trace)가 클라이언트에 노출되지 않도록 보강했습니다.

2. ErrorCode Enum 및 커스텀 예외 클래스 설계
애플리케이션에서 발생할 수 있는 모든 비즈니스 예외 상황을 ErrorCode Enum으로 정의하여 에러 코드와 메시지를 체계적으로 관리하도록 했습니다. (예: MEMBER_NOT_FOUND, INVALID_INPUT_VALUE)
ErrorCode를 포함하는 BusinessException과, 이를 상속하는 EntityNotFoundException 등 의미적으로 명확한 커스텀 예외 클래스들을 추가했습니다.

3. 서비스 로직 내 예외 처리 방식 변경
기존에 throw new RuntimeException("메시지")으로 처리하던 모든 부분을, 새롭게 정의된 커스텀 예외(예: throw new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND))를 사용하도록 전면 수정했습니다.

4. ErrorResponse DTO 추가
모든 에러 응답이 { "status": 404, "code": "M001", "message": "해당 사용자를 찾을 수 없습니다." }와 같이 일관된 JSON 형식을 갖도록 ErrorResponse DTO를 추가하고 적용했습니다.

🙏 리뷰 요청 사항
ErrorCode의 적절성: 현재 ErrorCode Enum에 정의된 에러 코드와 메시지들이 각 상황을 명확하게 나타내고 있는지 검토 부탁드립니다. 더 추가하거나 개선할 부분이 있을까요?
커스텀 예외 처리 범위: 현재 설계된 커스텀 예외들 외에, 추가적으로 특별하게 처리해야 할 예외 케이스가 있는지 확인 부탁드립니다. (예: DataIntegrityViolationException 등)
코드 컨벤션: 전역 예외 처리 로직이 저희 팀의 코드 컨벤션 및 설계 패턴에 잘 부합하는지 전반적인 리뷰 부탁드립니다.
