### PR TITLE
Feat#246 challenge log admin 검증 기능

### DIFF
--- a/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
@@ -26,4 +26,9 @@ public interface ChallengeLogDAO {
     // 챌린지 참여자 기록 조회
     List<ChallengeLogVO> findLogsByUserChallengeId(Map<String, Object> params);
 
+    // 수동 챌린지 인증
+    ChallengeLogVO selectLogById(Long logId);
+    void updateChallengeLog(ChallengeLogVO log);
+
+
 }

--- a/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
+++ b/backend_set/src/main/java/org/funding/challengeLog/dao/ChallengeLogDAO.java
@@ -6,6 +6,7 @@ import org.funding.challengeLog.vo.ChallengeLogVO;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @Mapper
 public interface ChallengeLogDAO {
@@ -19,7 +20,10 @@ public interface ChallengeLogDAO {
     // 중복 방지
     boolean existsByUserChallengeIdAndLogDate(@Param("userChallengeId") Long userChallengeId, @Param("logDate") LocalDate logDate);
 
+    // 챌린지 참여자 조회
     List<ChallengeLogVO> selectAllLogsByUserChallengeId(Long userChallengeId);
 
+    // 챌린지 참여자 기록 조회
+    List<ChallengeLogVO> findLogsByUserChallengeId(Map<String, Object> params);
 
 }

--- a/backend_set/src/main/java/org/funding/config/ServletConfig.java
+++ b/backend_set/src/main/java/org/funding/config/ServletConfig.java
@@ -63,7 +63,6 @@ import java.util.List;
         "org.funding.userLoan.controller",
         "org.funding.userSaving.controller",
         "org.funding.challengeLog.controller"
-
 }) // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/backend_set/src/main/java/org/funding/global/error/ErrorCode.java
+++ b/backend_set/src/main/java/org/funding/global/error/ErrorCode.java
@@ -93,7 +93,10 @@ public enum ErrorCode {
     // 저축 에러
     NOT_FOUND_SAVING(400, "SAVING001", "해당 저축에 신청되어있지 않습니다."),
     NO_CANCEL_SAVING(401, "SAVING002", "저축 해지 권한이 없습니다."),
-    ALREADY_JOINED_SAVING(400, "SAVING003", "이미 가입한 저축 상품입니다.")
+    ALREADY_JOINED_SAVING(400, "SAVING003", "이미 가입한 저축 상품입니다."),
+
+    // 휴먼 검증 챌린지 에러
+    NOT_HUMAN_VERIFY_TARGET(400, "NO_HUMAN", "휴먼 검증 대상이 아닙니다.")
     ;
 
 

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/ChallengeAdminController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/ChallengeAdminController.java
@@ -1,14 +1,12 @@
 package org.funding.userChallenge.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.funding.challengeLog.vo.ChallengeLogVO;
 import org.funding.security.util.Auth;
 import org.funding.userChallenge.dto.ChallengeParticipantDTO;
 import org.funding.userChallenge.service.UserChallengeService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -29,4 +27,18 @@ public class ChallengeAdminController {
         List<ChallengeParticipantDTO> participants = userChallengeService.getChallengeParticipants(fundId, creatorId);
         return ResponseEntity.ok(participants);
     }
+
+    // 특정 참여자 챌린지 기록 조회
+    @Auth
+    @GetMapping("/logs/{userChallengeId}")
+    public ResponseEntity<List<ChallengeLogVO>> getParticipantLogs(
+            @PathVariable Long userChallengeId,
+            @RequestParam(required = false) String status,
+            HttpServletRequest request) {
+        Long creatorId = (Long) request.getAttribute("userId");
+        List<ChallengeLogVO> logs = userChallengeService.getParticipantLogs(userChallengeId, status, creatorId);
+        return ResponseEntity.ok(logs);
+    }
+
+    //
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/ChallengeAdminController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/ChallengeAdminController.java
@@ -40,5 +40,21 @@ public class ChallengeAdminController {
         return ResponseEntity.ok(logs);
     }
 
-    //
+    // 수동 챌린지 검증 (승인)
+    @Auth
+    @PatchMapping("/logs/{logId}/approve")
+    public ResponseEntity<String> manuallyApproveLog(@PathVariable Long logId, HttpServletRequest request) {
+        Long creatorId = (Long) request.getAttribute("userId");
+        userChallengeService.manuallyVerifyLog(logId, creatorId, true); // true for approve
+        return ResponseEntity.ok("수동 승인 처리 완료");
+    }
+
+    // 수동 챌린지 검증 (반려)
+    @Auth
+    @PatchMapping("/logs/{logId}/reject")
+    public ResponseEntity<String> manuallyRejectLog(@PathVariable Long logId, HttpServletRequest request) {
+        Long creatorId = (Long) request.getAttribute("userId");
+        userChallengeService.manuallyVerifyLog(logId, creatorId, false); // false for reject
+        return ResponseEntity.ok("수동 반려 처리 완료");
+    }
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/ChallengeAdminController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/ChallengeAdminController.java
@@ -45,7 +45,7 @@ public class ChallengeAdminController {
     @PatchMapping("/logs/{logId}/approve")
     public ResponseEntity<String> manuallyApproveLog(@PathVariable Long logId, HttpServletRequest request) {
         Long creatorId = (Long) request.getAttribute("userId");
-        userChallengeService.manuallyVerifyLog(logId, creatorId, true); // true for approve
+        userChallengeService.manuallyVerifyLog(logId, creatorId, true);
         return ResponseEntity.ok("수동 승인 처리 완료");
     }
 

--- a/backend_set/src/main/java/org/funding/userChallenge/controller/ChallengeAdminController.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/controller/ChallengeAdminController.java
@@ -1,0 +1,32 @@
+package org.funding.userChallenge.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.funding.security.util.Auth;
+import org.funding.userChallenge.dto.ChallengeParticipantDTO;
+import org.funding.userChallenge.service.UserChallengeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/challenge")
+@RequiredArgsConstructor
+public class ChallengeAdminController {
+
+    private final UserChallengeService userChallengeService;
+
+    // 챌린지 참여자 목록 조회
+    @Auth
+    @GetMapping("/{fundId}/participants")
+    public ResponseEntity<List<ChallengeParticipantDTO>> getChallengeParticipants(@PathVariable("fundId") Long fundId,
+                                                                                  HttpServletRequest request) {
+        Long creatorId = (Long) request.getAttribute("userId");
+        List<ChallengeParticipantDTO> participants = userChallengeService.getChallengeParticipants(fundId, creatorId);
+        return ResponseEntity.ok(participants);
+    }
+}

--- a/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
@@ -3,6 +3,7 @@ package org.funding.userChallenge.dao;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.funding.challengeLog.vo.ChallengeLogVO;
+import org.funding.userChallenge.dto.ChallengeParticipantDTO;
 import org.funding.userChallenge.dto.UserChallengeDetailDTO;
 import org.funding.userChallenge.vo.UserChallengeVO;
 
@@ -36,5 +37,7 @@ public interface UserChallengeDAO {
 
     // 펀딩 id로 유저 참여했는지 판별
     boolean existsByUserIdAndFundId(@Param("userId") Long userId, @Param("fundId") Long fundId);
+
+    List<ChallengeParticipantDTO> findParticipantsByFundId(Long fundId);
 
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dao/UserChallengeDAO.java
@@ -40,4 +40,7 @@ public interface UserChallengeDAO {
 
     List<ChallengeParticipantDTO> findParticipantsByFundId(Long fundId);
 
+    void incrementSuccessCount(Long userChallengeId);
+    void incrementFailCount(Long userChallengeId);
+
 }

--- a/backend_set/src/main/java/org/funding/userChallenge/dto/ChallengeParticipantDTO.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/dto/ChallengeParticipantDTO.java
@@ -1,0 +1,16 @@
+package org.funding.userChallenge.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ChallengeParticipantDTO {
+    private Long userChallengeId;
+    private Long userId;
+    private String username;
+    private String nickname;
+    private int currentCount;
+    private int failCount;
+//    private LocalDateTime joinAt; // 챌린지 참여 시작일
+}

--- a/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
+++ b/backend_set/src/main/java/org/funding/userChallenge/service/UserChallengeService.java
@@ -20,10 +20,7 @@ import org.funding.openAi.dto.VisionResponseDTO;
 import org.funding.user.dao.MemberDAO;
 import org.funding.user.vo.MemberVO;
 import org.funding.userChallenge.dao.UserChallengeDAO;
-import org.funding.userChallenge.dto.ApplyChallengeRequestDTO;
-import org.funding.userChallenge.dto.ChallengeDetailResponseDTO;
-import org.funding.userChallenge.dto.DeleteChallengeRequestDTO;
-import org.funding.userChallenge.dto.UserChallengeDetailDTO;
+import org.funding.userChallenge.dto.*;
 import org.funding.userChallenge.vo.UserChallengeVO;
 import org.springframework.stereotype.Service;
 
@@ -231,5 +228,26 @@ public class UserChallengeService {
         responseDTO.setDailyLogs(dailyLogs);
 
         return responseDTO;
+    }
+
+
+    // 챌린지 참여자 조회
+    public List<ChallengeParticipantDTO> getChallengeParticipants(Long fundId, Long creatorId) {
+        // 1. 챌린지 생성자가 맞는지 보안 검증
+        verifyChallengeCreator(fundId, creatorId);
+
+        // 2. DAO를 통해 참여자 목록 조회
+        return userChallengeDAO.findParticipantsByFundId(fundId);
+    }
+
+    // (공통 로직) 챌린지 생성자가 맞는지 확인하는 헬퍼 메서드
+    private void verifyChallengeCreator(Long fundId, Long creatorId) {
+        FundVO fund = fundDAO.selectById(fundId);
+        if (fund == null) {
+            throw new UserChallengeException(ErrorCode.FUNDING_NOT_FOUND);
+        }
+        if (!fund.getUploadUserId().equals(creatorId)) {
+            throw new UserChallengeException(ErrorCode.AUTHENTICATION_FAILED); // 권한 없음 에러
+        }
     }
 }

--- a/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
+++ b/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
@@ -43,5 +43,19 @@
         )
     </select>
 
+    <select id="findLogsByUserChallengeId" parameterType="map" resultType="org.funding.challengeLog.vo.ChallengeLogVO">
+        SELECT
+        log_id, user_challenge_id, user_id, verified, image_url, verified_result, log_date, create_at
+        FROM
+        challenge_log
+        WHERE
+        user_challenge_id = #{userChallengeId}
+        <if test="status != null and status != ''">
+            AND verified = #{status}
+        </if>
+        ORDER BY
+        log_date DESC
+    </select>
+
 
 </mapper>

--- a/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
+++ b/backend_set/src/main/resources/org/funding/challengeLog/dao/ChallengeLogDAO.xml
@@ -43,6 +43,7 @@
         )
     </select>
 
+<!--     특정 사용자 챌린지 기록-->
     <select id="findLogsByUserChallengeId" parameterType="map" resultType="org.funding.challengeLog.vo.ChallengeLogVO">
         SELECT
         log_id, user_challenge_id, user_id, verified, image_url, verified_result, log_date, create_at
@@ -56,6 +57,43 @@
         ORDER BY
         log_date DESC
     </select>
+
+<!--    수동 챌린지 인증-->
+    <select id="selectLogById" parameterType="long" resultType="org.funding.challengeLog.vo.ChallengeLogVO">
+        SELECT
+            log_id,
+            user_challenge_id,
+            user_id,
+            verified,
+            image_url,
+            verified_result,
+            log_date,
+            create_at
+        FROM
+            challenge_log
+        WHERE
+            log_id = #{logId}
+    </select>
+
+    <update id="updateChallengeLog" parameterType="org.funding.challengeLog.vo.ChallengeLogVO">
+        UPDATE challenge_log
+        SET
+            verified = #{verified},
+            verified_result = #{verifiedResult}
+        WHERE log_id = #{logId}
+    </update>
+
+    <update id="incrementSuccessCount" parameterType="long">
+        UPDATE user_challenge
+        SET current_count = current_count + 1
+        WHERE user_challenge_id = #{userChallengeId}
+    </update>
+
+    <update id="incrementFailCount" parameterType="long">
+        UPDATE user_challenge
+        SET fail_count = fail_count + 1
+        WHERE user_challenge_id = #{userChallengeId}
+    </update>
 
 
 </mapper>

--- a/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
@@ -142,4 +142,17 @@
             uc.create_at DESC
     </select>
 
+    <update id="incrementSuccessCount" parameterType="long">
+        UPDATE user_challenge
+        SET current_count = current_count + 1
+        WHERE user_challenge_id = #{userChallengeId}
+    </update>
+
+    <update id="incrementFailCount" parameterType="long">
+        UPDATE user_challenge
+        SET fail_count = fail_count + 1
+        WHERE user_challenge_id = #{userChallengeId}
+    </update>
+
+
 </mapper>

--- a/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
+++ b/backend_set/src/main/resources/org/funding/userChallenge/dao/UserChallengeDAO.xml
@@ -123,4 +123,23 @@
         WHERE user_id = #{userId} AND fund_id = #{fundId}
     </select>
 
+    <select id="findParticipantsByFundId" parameterType="long" resultType="org.funding.userChallenge.dto.ChallengeParticipantDTO">
+        SELECT
+            uc.user_challenge_id AS userChallengeId,
+            uc.user_id AS userId,
+            m.username AS username,
+            m.nickname AS nickname,
+            uc.current_count AS currentCount,
+            uc.fail_count AS failCount,
+--             uc.create_at AS joinAt
+        FROM
+            user_challenge uc
+                JOIN
+            member m ON uc.user_id = m.user_id
+        WHERE
+            uc.fund_id = #{fundId}
+        ORDER BY
+            uc.create_at DESC
+    </select>
+
 </mapper>


### PR DESCRIPTION
📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
[x] 기능 추가
[ ] 기능 삭제
[ ] 버그 수정
[ ] 코드 리팩토링
[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
[ ] 코드에 영향을 주지 않는 변경사항 (ex. 오타 수정, 탭 사이즈 변경, 변수명 변경)

📌 이슈 번호
close #246 

✨ 반영 브랜치
feat#246-challenge-log-admin -> develop

🙏 리뷰 요청 사항
AI가 판별하기 애매한 챌린지 인증샷(HumanVerify)을 챌린지 생성자가 직접 검증(승인/반려)할 수 있는 관리 기능 API를 구현했습니다.

주요 기능 및 API 🚀
1. 챌린지 참여자 목록 조회 API
GET /api/admin/challenge/{fundId}/participants
특정 챌린지에 참여한 모든 사용자 목록을 조회합니다.
챌린지 생성자(uploadUserId)만 조회가 가능하도록 보안 검증 로직을 포함했습니다.

2. 참여자 인증 기록 조회 API (+필터링)
GET /api/admin/challenge/logs/{userChallengeId}
특정 참여자의 모든 인증 기록을 조회하며, ?status= 쿼리 파라미터를 통해 상태별(HumanVerify, Verified 등) 필터링이 가능합니다.

3. 수동 검증 처리 API (승인/반려)
PATCH /api/admin/challenge/logs/{logId}/approve
PATCH /api/admin/challenge/logs/{logId}/reject
HumanVerify 상태인 인증 기록을 생성자가 직접 Verified 또는 UnVerified로 변경합니다.
처리 시, 해당 유저의 성공/실패 카운트도 함께 업데이트되도록 **@Transactional**을 적용하여 데이터 정합성을 보장했습니다.
